### PR TITLE
Expand rich RTF previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4978,6 +4978,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rtf-grimoire"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed66ceebc3c35afb4f9bfb655c174f0072c7ad69e03e91a7ebc4b1c1adba4d1"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5514,7 +5523,10 @@ dependencies = [
 name = "sourcefour-doc"
 version = "0.1.0"
 dependencies = [
+ "encoding_rs",
  "pulldown-cmark",
+ "rtf-grimoire",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ authors = ["Sourcefour contributors"]
 [workspace.dependencies]
 gix = "0.85.0"
 gix-imara-diff = { version = "0.2.4", features = ["unified_diff"] }
+encoding_rs = "0.8.35"
 pulldown-cmark = { version = "0.13.4", default-features = false }
+rtf-grimoire = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.15.1"

--- a/apps/sourcefour/assets/icons/folder-plus.svg
+++ b/apps/sourcefour/assets/icons/folder-plus.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v0.525.0 - ISC -->
+<svg
+  class="lucide lucide-folder-plus"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 10v6" />
+  <path d="M9 13h6" />
+  <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+</svg>

--- a/apps/sourcefour/src/app.rs
+++ b/apps/sourcefour/src/app.rs
@@ -362,45 +362,9 @@ impl SourcefourAssets {
     }
 }
 
-/// Every asset the interface can ask for, compiled into the binary.
-///
-/// Reading these from disk would mean a different layout per install channel —
-/// a macOS bundle's Resources, an installer's program directory, a bare
-/// `cargo install`ed binary with no directory at all. Embedding them means the
-/// binary is the whole app wherever it lands. Add a file here when you add one
-/// to `assets/`.
-/// `include_bytes!` needs a literal path, so this names each file once and
-/// derives both the lookup key and the bytes from it.
-macro_rules! asset {
-    ($path:literal) => {
-        (
-            $path,
-            include_bytes!(concat!("../assets/", $path)).as_slice(),
-        )
-    };
-}
-
-const ASSETS: &[(&str, &[u8])] = &[
-    asset!("icons/archive.svg"),
-    asset!("icons/arrow-down-to-line.svg"),
-    asset!("icons/arrow-up-from-line.svg"),
-    asset!("icons/chevron-left.svg"),
-    asset!("icons/chevron-up.svg"),
-    asset!("icons/chevron-down.svg"),
-    asset!("icons/chevron-right.svg"),
-    asset!("icons/cloud-download.svg"),
-    asset!("icons/git-branch.svg"),
-    asset!("icons/git-commit-horizontal.svg"),
-    asset!("icons/git-merge.svg"),
-    asset!("icons/folder.svg"),
-    asset!("icons/globe.svg"),
-    asset!("icons/search.svg"),
-    asset!("icons/settings.svg"),
-];
-
 impl AssetSource for SourcefourAssets {
     fn load(&self, path: &str) -> Result<Option<Cow<'static, [u8]>>> {
-        Ok(ASSETS
+        Ok(crate::icons::ASSETS
             .iter()
             .find(|(name, _)| *name == path)
             .map(|(_, bytes)| Cow::Borrowed(*bytes)))
@@ -408,7 +372,7 @@ impl AssetSource for SourcefourAssets {
 
     fn list(&self, path: &str) -> Result<Vec<SharedString>> {
         let prefix = path.trim_end_matches('/');
-        Ok(ASSETS
+        Ok(crate::icons::ASSETS
             .iter()
             .filter_map(|(name, _)| name.strip_prefix(prefix)?.strip_prefix('/'))
             .map(SharedString::from)
@@ -432,7 +396,7 @@ mod tests {
         Launch, SourcefourAssets, clamped_window_size, display_path, history_keymap,
         launch_exit_code,
     };
-    use crate::LaunchRequest;
+    use crate::{LaunchRequest, icons::Icon};
 
     fn request(path: impl Into<PathBuf>, demo: bool) -> LaunchRequest {
         LaunchRequest {
@@ -542,6 +506,19 @@ mod tests {
                 loaded.is_some_and(|bytes| !bytes.is_empty()),
                 "{path} is on disk but not in ASSETS — an installed build would \
                  render it as a blank square"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn every_typed_icon_resolves_to_an_embedded_asset() -> Result<(), Box<dyn std::error::Error>> {
+        for icon in Icon::ALL {
+            let loaded = SourcefourAssets.load(icon.path())?;
+            assert!(
+                loaded.is_some_and(|bytes| !bytes.is_empty()),
+                "{} is in Icon::ALL but is not embedded",
+                icon.path()
             );
         }
         Ok(())

--- a/apps/sourcefour/src/history.rs
+++ b/apps/sourcefour/src/history.rs
@@ -6,7 +6,8 @@ use std::collections::HashSet;
 
 use sourcefour_graph::GraphState;
 use sourcefour_model::{
-    BranchSnapshot, CommitRow, GitTime, GraphRow, HistoryScope, Oid, WorkingTreeSummary,
+    BranchSnapshot, CommitRow, GitTime, GraphRow, HistoryScope, Oid, RemoteSnapshot,
+    WorkingTreeSummary,
 };
 
 use crate::settings::DateDisplay;
@@ -318,14 +319,22 @@ pub(crate) fn toggled_scope(
 pub(crate) fn refreshed_scope(
     current: Option<&HistoryScope>,
     branches: &[BranchSnapshot],
+    remotes: &[RemoteSnapshot],
 ) -> HistoryScope {
     match current {
         Some(HistoryScope::Ref { full_name, .. }) => branches
             .iter()
-            .find(|branch| branch.full_name == *full_name)
-            .map_or(HistoryScope::AllRefs, |branch| HistoryScope::Ref {
+            .map(|branch| (&branch.full_name, branch.tip))
+            .chain(
+                remotes
+                    .iter()
+                    .flat_map(|remote| &remote.branches)
+                    .map(|branch| (&branch.full_name, branch.tip)),
+            )
+            .find(|(name, _)| **name == *full_name)
+            .map_or(HistoryScope::AllRefs, |(_, tip)| HistoryScope::Ref {
                 full_name: full_name.clone(),
-                tip: branch.tip,
+                tip,
             }),
         _ => HistoryScope::AllRefs,
     }
@@ -463,12 +472,37 @@ mod tests {
         let branches = [branch_snapshot("refs/heads/main", oid(9))];
 
         assert_eq!(
-            refreshed_scope(Some(&scoped), &branches),
+            refreshed_scope(Some(&scoped), &branches, &[]),
             HistoryScope::Ref {
                 full_name: String::from("refs/heads/main"),
                 tip: oid(9),
             },
             "the restarted walk must see commits added since the last snapshot"
+        );
+    }
+
+    #[test]
+    fn a_refresh_keeps_a_remote_branch_scope() {
+        let scoped = HistoryScope::Ref {
+            full_name: String::from("refs/remotes/origin/feature/x"),
+            tip: oid(1),
+        };
+        let remotes = [sourcefour_model::RemoteSnapshot {
+            name: String::from("origin"),
+            fetch_url: None,
+            default_branch: None,
+            branches: vec![sourcefour_model::RemoteBranchSnapshot {
+                full_name: String::from("refs/remotes/origin/feature/x"),
+                short_name: String::from("origin/feature/x"),
+                tip: oid(8),
+            }],
+        }];
+        assert_eq!(
+            refreshed_scope(Some(&scoped), &[], &remotes),
+            HistoryScope::Ref {
+                full_name: String::from("refs/remotes/origin/feature/x"),
+                tip: oid(8),
+            }
         );
     }
 
@@ -481,14 +515,14 @@ mod tests {
         let branches = [branch_snapshot("refs/heads/main", oid(9))];
 
         assert_eq!(
-            refreshed_scope(Some(&scoped), &branches),
+            refreshed_scope(Some(&scoped), &branches, &[]),
             HistoryScope::AllRefs
         );
         assert_eq!(
-            refreshed_scope(Some(&HistoryScope::AllRefs), &branches),
+            refreshed_scope(Some(&HistoryScope::AllRefs), &branches, &[]),
             HistoryScope::AllRefs
         );
-        assert_eq!(refreshed_scope(None, &branches), HistoryScope::AllRefs);
+        assert_eq!(refreshed_scope(None, &branches, &[]), HistoryScope::AllRefs);
     }
 
     fn branch_snapshot(full_name: &str, tip: Oid) -> sourcefour_model::BranchSnapshot {

--- a/apps/sourcefour/src/icons.rs
+++ b/apps/sourcefour/src/icons.rs
@@ -1,0 +1,49 @@
+//! Typed identities for every SVG embedded in the application.
+
+macro_rules! define_icons {
+    ($($variant:ident => $file:literal),+ $(,)?) => {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        pub(crate) enum Icon {
+            $($variant),+
+        }
+
+        impl Icon {
+            #[cfg(test)]
+            pub(crate) const ALL: &[Self] = &[$(Self::$variant),+];
+
+            pub(crate) const fn path(self) -> &'static str {
+                match self {
+                    $(Self::$variant => concat!("icons/", $file)),+
+                }
+            }
+        }
+
+        pub(crate) const ASSETS: &[(&str, &[u8])] = &[
+            $(
+                (
+                    concat!("icons/", $file),
+                    include_bytes!(concat!("../assets/icons/", $file)).as_slice(),
+                )
+            ),+
+        ];
+    };
+}
+
+define_icons! {
+    Archive => "archive.svg",
+    ArrowDownToLine => "arrow-down-to-line.svg",
+    ArrowUpFromLine => "arrow-up-from-line.svg",
+    ChevronDown => "chevron-down.svg",
+    ChevronLeft => "chevron-left.svg",
+    ChevronRight => "chevron-right.svg",
+    ChevronUp => "chevron-up.svg",
+    CloudDownload => "cloud-download.svg",
+    Folder => "folder.svg",
+    FolderPlus => "folder-plus.svg",
+    GitBranch => "git-branch.svg",
+    GitCommitHorizontal => "git-commit-horizontal.svg",
+    GitMerge => "git-merge.svg",
+    Globe => "globe.svg",
+    Search => "search.svg",
+    Settings => "settings.svg",
+}

--- a/apps/sourcefour/src/main.rs
+++ b/apps/sourcefour/src/main.rs
@@ -6,6 +6,7 @@ mod diff_highlight;
 mod diff_split;
 mod graph_paint;
 mod history;
+mod icons;
 mod panels;
 mod persist;
 mod settings;

--- a/apps/sourcefour/src/settings.rs
+++ b/apps/sourcefour/src/settings.rs
@@ -65,6 +65,20 @@ pub(crate) struct GitSettings {
     /// are gone from the remote. Off by default: deleting refs is not what
     /// someone who pressed Fetch asked for.
     pub(crate) fetch_prune: bool,
+    /// Where generated linked-worktree paths are placed.
+    pub(crate) worktree_location: WorktreeLocation,
+}
+
+/// Layout used when suggesting a path for a new linked worktree.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum WorktreeLocation {
+    /// Place the checkout below `.worktrees` in the main worktree.
+    InsideRepository,
+    /// Place the checkout beside the repository's main worktree.
+    #[default]
+    #[serde(other)]
+    Sibling,
 }
 
 /// The GitHub integration's configuration (§ post-v1 integrations).
@@ -211,7 +225,7 @@ impl AppSettings {
 mod tests {
     use super::{
         AppSettings, AppearanceSettings, AuthMethod, DateDisplay, Density, DiffSettings,
-        GitSettings, GithubSettings, HistorySettings, VideoSettings,
+        GitSettings, GithubSettings, HistorySettings, VideoSettings, WorktreeLocation,
     };
 
     #[test]
@@ -223,7 +237,10 @@ mod tests {
                 date_display: DateDisplay::Absolute,
                 mono_font: Some(String::from("JetBrains Mono")),
             },
-            git: GitSettings { fetch_prune: true },
+            git: GitSettings {
+                fetch_prune: true,
+                worktree_location: WorktreeLocation::InsideRepository,
+            },
             github: GithubSettings {
                 enabled: true,
                 auth_method: AuthMethod::Token,
@@ -418,6 +435,17 @@ mod tests {
             !GitSettings::default().fetch_prune,
             "a fetch that deletes local refs is never the unasked-for default"
         );
+        assert_eq!(
+            GitSettings::default().worktree_location,
+            WorktreeLocation::Sibling
+        );
+
+        std::fs::write(&path, r#"{"git": {"worktree_location": "future-layout"}}"#)?;
+        assert_eq!(
+            AppSettings::load_from(&path).git.worktree_location,
+            WorktreeLocation::Sibling,
+            "unknown layouts retain the safe default"
+        );
 
         std::fs::write(
             &path,
@@ -425,7 +453,10 @@ mod tests {
         )?;
         assert_eq!(
             AppSettings::load_from(&path).git,
-            GitSettings { fetch_prune: true },
+            GitSettings {
+                fetch_prune: true,
+                ..GitSettings::default()
+            },
             "a future key inside the section is ignored, not fatal"
         );
         Ok(())

--- a/apps/sourcefour/src/settings_ui.rs
+++ b/apps/sourcefour/src/settings_ui.rs
@@ -8,7 +8,8 @@
 use gpui::{Div, FocusableWrapper, FontWeight, div, prelude::*, px, svg};
 
 use crate::{
-    settings::{AppSettings, AuthMethod, DateDisplay, Density},
+    icons::Icon,
+    settings::{AppSettings, AuthMethod, DateDisplay, Density, WorktreeLocation},
     theme::Theme,
     views::SourcefourWindow,
 };
@@ -273,6 +274,18 @@ fn general_cards(view: &SettingsView<'_>, cx: &mut gpui::Context<SourcefourWindo
                     choices: &[("Off", false), ("On", true)],
                     active: view.settings.git.fetch_prune,
                     apply: |settings, prune| settings.git.fetch_prune = prune,
+                }
+                .row(theme, cx),
+                Choice {
+                    id: "worktree-location",
+                    name: "New worktrees",
+                    description: "Where generated worktree paths are placed by default.",
+                    choices: &[
+                        ("Beside repository", WorktreeLocation::Sibling),
+                        ("Inside .worktrees", WorktreeLocation::InsideRepository),
+                    ],
+                    active: view.settings.git.worktree_location,
+                    apply: |settings, location| settings.git.worktree_location = location,
                 }
                 .row(theme, cx),
             ],
@@ -677,7 +690,7 @@ pub(crate) fn toolbar_button(theme: &Theme, cx: &mut gpui::Context<SourcefourWin
             }))
             .child(
                 svg()
-                    .path("icons/settings.svg")
+                    .path(Icon::Settings.path())
                     .size(px(14.0))
                     .text_color(theme.text_secondary),
             ),

--- a/apps/sourcefour/src/text_input.rs
+++ b/apps/sourcefour/src/text_input.rs
@@ -125,6 +125,7 @@ pub(crate) enum InputRole {
     HistoryFilter,
     DiffSwitcher,
     BranchName,
+    WorktreePath,
     GithubToken,
     CommitMessage,
 }

--- a/apps/sourcefour/src/views.rs
+++ b/apps/sourcefour/src/views.rs
@@ -20,7 +20,10 @@ use gpui::{
     Div, FocusHandle, FontWeight, IntoElement, Render, UniformListScrollHandle, Window, actions,
     div, prelude::*, px,
 };
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use sourcefour_git::{GixHistoryCursor, HistoryCursor as _};
 use sourcefour_model::{
@@ -47,11 +50,13 @@ mod github;
 mod history_pane;
 mod preview;
 mod sidebar;
+mod worktree_dialog;
 
 use branch_dialog::BranchDialog;
 use diff::{DiffMode, DiffView};
 use github::{Cached, GithubChecks};
 use sidebar::{SidebarSections, head_label};
+use worktree_dialog::WorktreeDialog;
 
 struct DiffCacheEntry {
     request: sourcefour_model::FileDiffRequest,
@@ -74,6 +79,8 @@ pub(crate) struct SourcefourWindow {
     /// Identity every background result must match to be applied.
     session: RepoSessionId,
     generation: Generation,
+    /// Cancels metadata polling for a worktree that is no longer active.
+    metadata_watch_generation: Arc<AtomicU64>,
     /// Kept so a refresh can re-read without re-discovering.
     location: Option<RepoLocation>,
     repo: LoadState<RepoSnapshot>,
@@ -190,6 +197,12 @@ pub(crate) struct SourcefourWindow {
     branch_dialog: Option<BranchDialog>,
     /// Name field of the create-branch dialog.
     branch_input: gpui::Entity<crate::text_input::TextInput>,
+    /// Worktree creation dialog, when open.
+    worktree_dialog: Option<WorktreeDialog>,
+    /// Editable target path for a new linked worktree.
+    worktree_path_input: gpui::Entity<crate::text_input::TextInput>,
+    /// Retires an earlier worktree activation whose discovery finishes late.
+    worktree_activation_request: u64,
     /// Focus target of the details pane (§4.6: Enter focuses it).
     details_focus: FocusHandle,
     list_scroll: UniformListScrollHandle,
@@ -378,6 +391,7 @@ impl SourcefourWindow {
             window_save_generation: 0,
             session,
             generation,
+            metadata_watch_generation: Arc::new(AtomicU64::new(0)),
             location: None,
             repo: LoadState::Idle,
             history: HistoryState::default(),
@@ -450,6 +464,13 @@ impl SourcefourWindow {
                 crate::text_input::InputRole::BranchName,
                 cx,
             ),
+            worktree_dialog: None,
+            worktree_path_input: Self::input(
+                "worktree-path",
+                crate::text_input::InputRole::WorktreePath,
+                cx,
+            ),
+            worktree_activation_request: 0,
             list_scroll: UniformListScrollHandle::new(),
             focus: cx.focus_handle(),
             filter_input: Self::input(
@@ -486,7 +507,12 @@ impl SourcefourWindow {
             };
             window.location = Some(location.clone());
             window.load_metadata(location.clone(), cx);
-            Self::watch_metadata(location, cx);
+            Self::watch_metadata(
+                location,
+                Arc::clone(&window.metadata_watch_generation),
+                0,
+                cx,
+            );
         }
         window.focus.focus(gpui_window);
         window
@@ -575,11 +601,22 @@ impl SourcefourWindow {
     /// Polling at the §6.14 coalescing interval costs one stat pass over the
     /// metadata paths, which is far cheaper than a recursive worktree watcher
     /// and behaves identically on every platform.
-    fn watch_metadata(location: RepoLocation, cx: &mut gpui::Context<Self>) {
+    fn watch_metadata(
+        location: RepoLocation,
+        watch_generation: Arc<AtomicU64>,
+        generation: u64,
+        cx: &mut gpui::Context<Self>,
+    ) {
         cx.spawn(async move |this, cx| {
             let mut watcher = sourcefour_git::MetadataWatcher::new(&location);
             loop {
+                if watch_generation.load(Ordering::Acquire) != generation {
+                    return;
+                }
                 cx.background_executor().timer(METADATA_POLL).await;
+                if watch_generation.load(Ordering::Acquire) != generation {
+                    return;
+                }
                 // The watcher moves to the background thread and back rather
                 // than being cloned, so polling costs no allocation per tick.
                 let (change, returned) = cx
@@ -613,6 +650,90 @@ impl SourcefourWindow {
         self.snapshot()
             .and_then(|snapshot| snapshot.active_worktree.clone())
             .unwrap_or_else(|| sourcefour_model::WorktreeId(String::from("active")))
+    }
+
+    /// Changes every repository-scoped operation to an existing worktree.
+    pub(super) fn activate_worktree_path(
+        &mut self,
+        path: std::path::PathBuf,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        if self
+            .location
+            .as_ref()
+            .and_then(|location| location.active_worktree_path.as_ref())
+            == Some(&path)
+        {
+            return;
+        }
+        self.worktree_activation_request = self.worktree_activation_request.wrapping_add(1);
+        let request = self.worktree_activation_request;
+        cx.spawn(async move |this, cx| {
+            let discovered = cx
+                .background_executor()
+                .spawn(async move { sourcefour_git::discover(&path) })
+                .await;
+            this.update(cx, |this, cx| {
+                if this.worktree_activation_request != request {
+                    return;
+                }
+                match discovered {
+                    Ok(location) => {
+                        let selected = this.history.selected;
+                        let scope = this.history.scope.clone();
+                        let filter = this.history.filter.clone();
+                        this.session = RepoSessionId::new();
+                        this.generation = Generation(0);
+                        this.name = sourcefour_git::display_name(&location);
+                        this.path = crate::app::display_path(
+                            location
+                                .active_worktree_path
+                                .as_deref()
+                                .unwrap_or(&location.common_dir),
+                        );
+                        this.location = Some(location.clone());
+                        this.repo = LoadState::Loading {
+                            started_at: std::time::Instant::now(),
+                        };
+                        this.cursor = None;
+                        this.history = HistoryState::default();
+                        this.history.scope = scope;
+                        this.history.selected = selected;
+                        this.history.filter = filter;
+                        this.detail = None;
+                        this.files = None;
+                        this.files_for = None;
+                        this.working_tree_status = None;
+                        this.diff_view = None;
+                        this.initial_selection_pending = selected.is_none();
+                        this.status_request = this.status_request.wrapping_add(1);
+                        this.files_request = this.files_request.wrapping_add(1);
+                        this.diff_request = this.diff_request.wrapping_add(1);
+                        this.branch_dialog = None;
+                        this.worktree_dialog = None;
+                        this.network_operation.cancel_and_retire();
+                        this.load_metadata(location.clone(), cx);
+                        let watcher_generation = this
+                            .metadata_watch_generation
+                            .fetch_add(1, Ordering::AcqRel)
+                            .wrapping_add(1);
+                        Self::watch_metadata(
+                            location,
+                            Arc::clone(&this.metadata_watch_generation),
+                            watcher_generation,
+                            cx,
+                        );
+                        cx.notify();
+                    }
+                    Err(error) => {
+                        this.op_status = Some((false, error.user.message));
+                        cx.notify();
+                    }
+                }
+            })
+            .ok();
+        })
+        .detach();
     }
 
     /// Starts a metadata reload of the current location: a new generation
@@ -649,6 +770,10 @@ impl SourcefourWindow {
                 .as_ref()
                 .map(|snapshot| snapshot.local_branches.clone())
                 .unwrap_or_default();
+            let remotes = payload
+                .as_ref()
+                .map(|snapshot| snapshot.remotes.clone())
+                .unwrap_or_default();
             let applied = this
                 .update(cx, |this, cx| {
                     let applied = this.apply_snapshot(&RepoEnvelope {
@@ -665,7 +790,8 @@ impl SourcefourWindow {
                         // context: the scope survives with a re-resolved tip and
                         // the selection re-attaches when its commit reloads
                         // (§6.12).
-                        let scope = refreshed_scope(this.history.scope.as_ref(), &branches);
+                        let scope =
+                            refreshed_scope(this.history.scope.as_ref(), &branches, &remotes);
                         let selected = this.history.selected;
                         this.start_history(scope, cx);
                         this.history.selected = selected;
@@ -1326,6 +1452,8 @@ impl SourcefourWindow {
         .on_action(cx.listener(|this, _: &FilterEscape, window, cx| {
             if this.diff_switcher_open {
                 this.close_diff_file_switcher(window, cx);
+            } else if this.worktree_dialog.is_some() {
+                this.close_worktree_dialog(window, cx);
             } else if this.branch_dialog.is_some() {
                 this.branch_dialog = None;
                 this.focus.focus(window);
@@ -1341,6 +1469,8 @@ impl SourcefourWindow {
         .on_action(cx.listener(|this, _: &FilterEnter, window, cx| {
             if this.diff_switcher_open {
                 this.open_selected_diff_file(window, cx);
+            } else if this.worktree_dialog.is_some() {
+                this.submit_worktree_dialog(window, cx);
             } else if this.branch_dialog.is_some() {
                 this.submit_branch_dialog(window, cx);
             } else {
@@ -1574,6 +1704,7 @@ impl Render for SourcefourWindow {
             .child(self.status())
             .children(self.diff_overlay(cx))
             .children(self.branch_overlay(cx))
+            .children(self.worktree_overlay(cx))
             .children(self.settings_overlay(cx))
             .children(self.actions_overlay(window.viewport_size().height.0, cx));
         // §12.5 frame instrumentation: element construction only — layout,

--- a/apps/sourcefour/src/views/branch_dialog.rs
+++ b/apps/sourcefour/src/views/branch_dialog.rs
@@ -7,21 +7,137 @@ use super::SourcefourWindow;
 
 /// The §6.13 create-branch dialog's state; the name lives in its input.
 pub(super) struct BranchDialog {
+    source: BranchDialogSource,
     checkout: bool,
     running: bool,
     error: Option<String>,
 }
 
+#[derive(Clone)]
+enum BranchDialogSource {
+    Commit,
+    Remote {
+        full_name: String,
+        short_name: String,
+    },
+}
+
 impl SourcefourWindow {
+    /// Creates, checks out, or activates the local counterpart of a remote branch.
+    pub(super) fn use_remote_branch(
+        &mut self,
+        full_name: String,
+        short_name: String,
+        window: &mut Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let local_name = short_name
+            .split_once('/')
+            .map_or(short_name.as_str(), |(_, branch)| branch);
+        let existing = self.snapshot().and_then(|snapshot| {
+            snapshot
+                .local_branches
+                .iter()
+                .find(|branch| branch.short_name == local_name)
+                .cloned()
+        });
+        let Some(branch) = existing else {
+            self.open_tracking_dialog(full_name, short_name, window, cx);
+            return;
+        };
+        if branch
+            .upstream
+            .as_ref()
+            .map(|upstream| upstream.full_name.as_str())
+            != Some(full_name.as_str())
+        {
+            self.open_tracking_dialog(full_name, short_name, window, cx);
+            return;
+        }
+        if branch.is_current {
+            return;
+        }
+        if let Some(worktree) = branch.checked_out_in.and_then(|id| {
+            self.snapshot()?
+                .worktrees
+                .iter()
+                .find(|tree| tree.id == id)
+                .cloned()
+        }) {
+            self.activate_worktree_path(worktree.path, cx);
+            return;
+        }
+        let Some(location) = self.location.clone() else {
+            return;
+        };
+        let request = sourcefour_model::CheckoutBranchRequest {
+            worktree: self.active_worktree_id(),
+            full_name: branch.full_name,
+        };
+        cx.spawn(async move |this, cx| {
+            let outcome = cx
+                .background_executor()
+                .spawn(async move { sourcefour_git::checkout_branch(&location, &request) })
+                .await;
+            this.update(cx, |this, cx| {
+                match outcome {
+                    Ok(OperationOutcome::Succeeded { summary, .. }) => {
+                        this.op_status = Some((true, summary));
+                        this.begin_reload(cx);
+                    }
+                    Ok(OperationOutcome::Failed { error, .. }) | Err(error) => {
+                        this.op_status = Some((false, error.user.message));
+                    }
+                    Ok(OperationOutcome::Cancelled { .. }) => {}
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
     /// Opens the §6.13 create-branch dialog seeded from the selection.
     pub(super) fn open_branch_dialog(&mut self, window: &mut Window, cx: &mut gpui::Context<Self>) {
         self.branch_dialog = Some(BranchDialog {
+            source: BranchDialogSource::Commit,
             checkout: false,
             running: false,
             error: None,
         });
         self.branch_input
             .update(cx, |input, cx| input.set_text("", cx));
+        self.branch_input
+            .read(cx)
+            .focus_handle
+            .clone()
+            .focus(window);
+        cx.notify();
+    }
+
+    /// Opens branch creation preconfigured to track a remote branch.
+    pub(super) fn open_tracking_dialog(
+        &mut self,
+        full_name: String,
+        short_name: String,
+        window: &mut Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let local_name = short_name
+            .split_once('/')
+            .map_or(short_name.as_str(), |(_, branch)| branch)
+            .to_owned();
+        self.branch_dialog = Some(BranchDialog {
+            source: BranchDialogSource::Remote {
+                full_name,
+                short_name,
+            },
+            checkout: true,
+            running: false,
+            error: None,
+        });
+        self.branch_input
+            .update(cx, |input, cx| input.set_text(&local_name, cx));
         self.branch_input
             .read(cx)
             .focus_handle
@@ -47,9 +163,10 @@ impl SourcefourWindow {
         cx: &mut gpui::Context<Self>,
     ) {
         let name = self.branch_input.read(cx).text().to_string();
-        let (Some(start), Some(location)) = (self.branch_start(), self.location.clone()) else {
+        let Some(location) = self.location.clone() else {
             return;
         };
+        let start = self.branch_start();
         let Some(dialog) = &mut self.branch_dialog else {
             return;
         };
@@ -57,19 +174,41 @@ impl SourcefourWindow {
             return;
         }
         let checkout = dialog.checkout;
+        let source = dialog.source.clone();
+        if matches!(source, BranchDialogSource::Commit) && start.is_none() {
+            return;
+        }
         dialog.running = true;
         dialog.error = None;
-        let request = sourcefour_model::CreateBranchRequest {
-            worktree: self.active_worktree_id(),
-            name,
-            start,
-            checkout,
-        };
+        let worktree = self.active_worktree_id();
         self.focus.focus(window);
         cx.spawn(async move |this, cx| {
             let outcome = cx
                 .background_executor()
-                .spawn(async move { sourcefour_git::create_branch(&location, &request) })
+                .spawn(async move {
+                    match source {
+                        BranchDialogSource::Commit => sourcefour_git::create_branch(
+                            &location,
+                            &sourcefour_model::CreateBranchRequest {
+                                worktree,
+                                name,
+                                start: start.expect("commit source was validated"),
+                                checkout,
+                            },
+                        ),
+                        BranchDialogSource::Remote { full_name, .. } => {
+                            sourcefour_git::track_remote_branch(
+                                &location,
+                                &sourcefour_model::TrackRemoteBranchRequest {
+                                    worktree,
+                                    remote_ref: full_name,
+                                    local_name: name,
+                                    checkout,
+                                },
+                            )
+                        }
+                    }
+                })
                 .await;
             this.update(cx, |this, cx| {
                 match outcome {
@@ -116,9 +255,16 @@ impl SourcefourWindow {
         let name = self.branch_input.read(cx).text().to_string();
         let creatable = !dialog.running && sourcefour_git::is_valid_branch_name(&name);
         let invalid = !name.is_empty() && !sourcefour_git::is_valid_branch_name(&name);
-        let start = self
-            .branch_start()
-            .map_or_else(|| String::from("HEAD"), |oid| oid.abbreviated(9));
+        let (title, start) = match &dialog.source {
+            BranchDialogSource::Commit => (
+                "Create branch",
+                self.branch_start()
+                    .map_or_else(|| String::from("HEAD"), |oid| oid.abbreviated(9)),
+            ),
+            BranchDialogSource::Remote { short_name, .. } => {
+                ("Track remote branch", short_name.clone())
+            }
+        };
         Some(
             super::modal_backdrop("branch-overlay", &self.theme)
                 .items_center()
@@ -141,7 +287,7 @@ impl SourcefourWindow {
                                 .text_size(px(13.0))
                                 .font_weight(FontWeight::SEMIBOLD)
                                 .text_color(self.theme.text_primary)
-                                .child("Create branch")
+                                .child(title)
                                 .child(
                                     div()
                                         .font_family(self.mono_font())

--- a/apps/sourcefour/src/views/chrome.rs
+++ b/apps/sourcefour/src/views/chrome.rs
@@ -8,6 +8,7 @@ use sourcefour_git::OperationSink;
 use sourcefour_model::{FetchRequest, OperationOutcome, OperationProgress, RepoSnapshot};
 
 use crate::{
+    icons::Icon,
     panels::Splitter,
     theme::{SPLITTER_WIDTH, STATUS_HEIGHT, TITLEBAR_HEIGHT, TOOLBAR_HEIGHT, Theme},
 };
@@ -22,7 +23,7 @@ pub(super) enum NetworkOperationState {
         generation: u64,
         op: NetworkOp,
         progress: Arc<Mutex<Option<OperationProgress>>>,
-        _cancel: Arc<AtomicBool>,
+        cancel: Arc<AtomicBool>,
     },
 }
 
@@ -33,6 +34,15 @@ impl Default for NetworkOperationState {
 }
 
 impl NetworkOperationState {
+    pub(super) fn cancel_and_retire(&mut self) {
+        if let Self::Running { cancel, .. } = self {
+            cancel.store(true, std::sync::atomic::Ordering::Release);
+        }
+        *self = Self::Idle {
+            generation: self.generation().wrapping_add(1),
+        };
+    }
+
     fn running_op(&self) -> Option<NetworkOp> {
         match self {
             Self::Idle { .. } => None,
@@ -94,11 +104,11 @@ impl NetworkOp {
         }
     }
 
-    fn icon(self) -> &'static str {
+    fn icon(self) -> Icon {
         match self {
-            Self::Fetch => "icons/cloud-download.svg",
-            Self::Push => "icons/arrow-up-from-line.svg",
-            Self::Pull => "icons/arrow-down-to-line.svg",
+            Self::Fetch => Icon::CloudDownload,
+            Self::Push => Icon::ArrowUpFromLine,
+            Self::Pull => Icon::ArrowDownToLine,
         }
     }
 }
@@ -133,7 +143,7 @@ fn status_summary(snapshot: &RepoSnapshot) -> String {
 
 fn filter_icon(theme: &Theme) -> gpui::Svg {
     svg()
-        .path("icons/search.svg")
+        .path(Icon::Search.path())
         .size(px(13.0))
         .text_color(theme.text_faint)
 }
@@ -178,9 +188,9 @@ impl SourcefourWindow {
             .child(self.operation_button(NetworkOp::Fetch, cx))
             .child(self.operation_button(NetworkOp::Pull, cx))
             .child(self.operation_button(NetworkOp::Push, cx))
-            .child(action("Commit", "icons/git-commit-horizontal.svg"))
+            .child(action("Commit", Icon::GitCommitHorizontal))
             .child(
-                self.toolbar_column("Branch", "icons/git-branch.svg", true)
+                self.toolbar_column("Branch", Icon::GitBranch, true)
                     .id("branch-action")
                     .cursor_pointer()
                     .hover(|style| style.bg(self.theme.bg_hover))
@@ -188,8 +198,8 @@ impl SourcefourWindow {
                         this.open_branch_dialog(window, cx);
                     })),
             )
-            .child(action("Merge", "icons/git-merge.svg"))
-            .child(action("Stash", "icons/archive.svg"))
+            .child(action("Merge", Icon::GitMerge))
+            .child(action("Stash", Icon::Archive))
             .child(div().flex_grow())
             .child(self.filter_box(window, cx))
             .child(crate::settings_ui::toolbar_button(&self.theme, cx))
@@ -197,7 +207,7 @@ impl SourcefourWindow {
 
     /// One toolbar column: icon above label, lit when active. Callers add
     /// identity and click behavior; planned actions stay inert and faint.
-    fn toolbar_column(&self, label: &'static str, icon: &'static str, active: bool) -> Div {
+    fn toolbar_column(&self, label: &'static str, icon: Icon, active: bool) -> Div {
         div()
             .h_full()
             .flex()
@@ -212,11 +222,16 @@ impl SourcefourWindow {
             } else {
                 self.theme.text_faint
             })
-            .child(svg().path(icon).size(px(15.0)).text_color(if active {
-                self.theme.accent
-            } else {
-                self.theme.text_faint
-            }))
+            .child(
+                svg()
+                    .path(icon.path())
+                    .size(px(15.0))
+                    .text_color(if active {
+                        self.theme.accent
+                    } else {
+                        self.theme.text_faint
+                    }),
+            )
             .child(label)
     }
 
@@ -300,6 +315,20 @@ impl SourcefourWindow {
     /// A second operation while one runs is a no-op: the buttons disable,
     /// and this guard holds even if a keybinding races the render.
     pub(super) fn start_operation(&mut self, op: NetworkOp, cx: &mut gpui::Context<Self>) {
+        self.start_operation_with_remote(op, None, cx);
+    }
+
+    /// Fetches one named remote from its sidebar header.
+    pub(super) fn fetch_remote(&mut self, remote: String, cx: &mut gpui::Context<Self>) {
+        self.start_operation_with_remote(NetworkOp::Fetch, Some(remote), cx);
+    }
+
+    fn start_operation_with_remote(
+        &mut self,
+        op: NetworkOp,
+        remote: Option<String>,
+        cx: &mut gpui::Context<Self>,
+    ) {
         if self.network_operation.running_op().is_some() {
             return;
         }
@@ -308,7 +337,7 @@ impl SourcefourWindow {
         };
         let request = FetchRequest {
             worktree: self.active_worktree_id(),
-            remote: None,
+            remote,
             prune: self.settings.git.fetch_prune,
         };
         let latest = Arc::new(Mutex::new(None));
@@ -318,7 +347,7 @@ impl SourcefourWindow {
             generation,
             op,
             progress: Arc::clone(&latest),
-            _cancel: Arc::clone(&cancel),
+            cancel: Arc::clone(&cancel),
         };
         self.op_status = None;
         cx.spawn(async move |this, cx| {
@@ -484,7 +513,7 @@ mod tests {
             generation,
             op,
             progress: Arc::new(Mutex::new(None)),
-            _cancel: Arc::new(AtomicBool::new(false)),
+            cancel: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/apps/sourcefour/src/views/diff.rs
+++ b/apps/sourcefour/src/views/diff.rs
@@ -17,6 +17,8 @@ use sourcefour_model::{
     RepoPath, TextDiff, VideoInfo,
 };
 
+use crate::icons::Icon;
+
 use super::{
     Drag, SourcefourWindow, change_color, change_letter, counted,
     preview::{self, PreviewSide, PreviewState},
@@ -1137,19 +1139,17 @@ impl SourcefourWindow {
                     let panes = div()
                         .size_full()
                         .flex()
-                        .child(
-                            div()
-                                .flex_1()
-                                .min_w(px(1.0))
-                                .child(preview::pane(&preview.old, PreviewSide::Old)),
-                        )
+                        .child(div().flex_1().min_w(px(1.0)).child(preview::pane(
+                            &preview.old,
+                            PreviewSide::Old,
+                            &self.theme,
+                        )))
                         .child(div().w(px(1.0)).flex_none().bg(self.theme.border))
-                        .child(
-                            div()
-                                .flex_1()
-                                .min_w(px(1.0))
-                                .child(preview::pane(&preview.new, PreviewSide::New)),
-                        )
+                        .child(div().flex_1().min_w(px(1.0)).child(preview::pane(
+                            &preview.new,
+                            PreviewSide::New,
+                            &self.theme,
+                        )))
                         .into_any_element();
                     preview::build_probe(
                         started,
@@ -1326,7 +1326,7 @@ impl SourcefourWindow {
                     .child(
                         self.icon_segment_button(
                             "previous-diff-file",
-                            "icons/chevron-left.svg",
+                            Icon::ChevronLeft,
                             previous_file_enabled,
                         )
                         .on_click(cx.listener(|this, _, window, cx| {
@@ -1336,7 +1336,7 @@ impl SourcefourWindow {
                     .child(
                         self.icon_segment_button(
                             "next-diff-file",
-                            "icons/chevron-right.svg",
+                            Icon::ChevronRight,
                             next_file_enabled,
                         )
                         .on_click(cx.listener(|this, _, window, cx| {
@@ -1361,7 +1361,7 @@ impl SourcefourWindow {
                     .child(
                         self.icon_segment_button(
                             "previous-diff-hunk",
-                            "icons/chevron-up.svg",
+                            Icon::ChevronUp,
                             previous_hunk_enabled,
                         )
                         .on_click(cx.listener(|this, _, _, cx| this.navigate_diff_hunk(-1, cx))),
@@ -1369,7 +1369,7 @@ impl SourcefourWindow {
                     .child(
                         self.icon_segment_button(
                             "next-diff-hunk",
-                            "icons/chevron-down.svg",
+                            Icon::ChevronDown,
                             next_hunk_enabled,
                         )
                         .on_click(cx.listener(|this, _, _, cx| this.navigate_diff_hunk(1, cx))),
@@ -1516,7 +1516,7 @@ impl SourcefourWindow {
     fn icon_segment_button(
         &self,
         id: &'static str,
-        path: &'static str,
+        icon: Icon,
         enabled: bool,
     ) -> gpui::Stateful<Div> {
         div()
@@ -1536,7 +1536,7 @@ impl SourcefourWindow {
             .when(!enabled, |button| button.opacity(0.4))
             .child(
                 svg()
-                    .path(path)
+                    .path(icon.path())
                     .size(px(14.0))
                     .text_color(self.theme.text_secondary),
             )

--- a/apps/sourcefour/src/views/preview.rs
+++ b/apps/sourcefour/src/views/preview.rs
@@ -1,4 +1,4 @@
-//! The diff overlay's rendered-document pane: Markdown, not diff lines.
+//! The diff overlay's rendered-document pane: documents, not diff lines.
 //!
 //! A Markdown file is two things at once — a patch and a document — and the
 //! header's Source/Preview toggle picks which one is on screen. The preview
@@ -187,6 +187,8 @@ pub(super) struct PreviewParse {
     blocks: Vec<DocBlock>,
     /// One entry per distinct image reference in `blocks`.
     images: HashMap<String, PreviewImage>,
+    /// A parse failure shown in this side's pane instead of an empty document.
+    error: Option<String>,
 }
 
 /// One side's document: its blocks, the images they resolved to, and the
@@ -196,6 +198,8 @@ pub(super) struct PreviewDoc {
     pub(super) blocks: Vec<DocBlock>,
     /// One entry per distinct image reference in `blocks`.
     pub(super) images: HashMap<String, PreviewImage>,
+    /// A format parser failure for this side.
+    error: Option<String>,
     /// One list item per top-level block, so a frame builds the blocks on
     /// screen instead of the document. Holds the scroll position, so it is
     /// built once per loaded document and never per frame.
@@ -237,6 +241,7 @@ impl PreviewDoc {
             ),
             blocks: parse.blocks,
             images: parse.images,
+            error: parse.error,
             side,
             view,
         }
@@ -254,11 +259,13 @@ pub(super) enum PreviewImage {
     Missing,
 }
 
-/// Whether the open diff could be previewed: a Markdown path whose diff came
-/// back as text. Nothing else has a renderer yet.
+/// Whether the open text diff has a document parser and can be previewed.
 pub(super) fn applies(view: &DiffView) -> bool {
     matches!(view.content, Some(DiffContent::Text(_)))
-        && DocumentKind::detect(&view.origin.path().0) == Some(DocumentKind::Markdown)
+        && matches!(
+            DocumentKind::detect(&view.origin.path().0),
+            Some(DocumentKind::Markdown | DocumentKind::Rtf)
+        )
 }
 
 /// Whether the preview is what the body should draw right now.
@@ -326,9 +333,12 @@ fn old_doc_source(
 ///
 /// A side without the document — the new side of a deletion, the old side of
 /// an addition — renders one notice rather than an empty pane.
-fn document_blocks(bytes: Option<&[u8]>) -> Vec<DocBlock> {
+fn document_blocks(
+    kind: DocumentKind,
+    bytes: Option<&[u8]>,
+) -> Result<Vec<DocBlock>, sourcefour_doc::DocumentParseError> {
     let Some(bytes) = bytes else {
-        return vec![DocBlock {
+        return Ok(vec![DocBlock {
             kind: DocBlockKind::Paragraph {
                 spans: vec![DocSpan {
                     text: String::from(ABSENT_NOTICE),
@@ -336,9 +346,9 @@ fn document_blocks(bytes: Option<&[u8]>) -> Vec<DocBlock> {
                 }],
             },
             source_range: 0..0,
-        }];
+        }]);
     };
-    sourcefour_doc::parse_markdown(&String::from_utf8_lossy(bytes))
+    sourcefour_doc::parse_document(kind, bytes)
 }
 
 /// Reads, parses, and resolves both sides, old first. Runs off the main
@@ -349,21 +359,32 @@ fn load(
     head: Option<sourcefour_model::Oid>,
 ) -> (PreviewParse, PreviewParse) {
     let path = origin.path().clone();
+    let kind = DocumentKind::detect(&path.0).unwrap_or(DocumentKind::Markdown);
     (
         load_side(
             location,
             old_doc_source(location, origin, head).as_ref(),
             &path,
+            kind,
         ),
-        load_side(location, doc_source(origin).as_ref(), &path),
+        load_side(location, doc_source(origin).as_ref(), &path, kind),
     )
 }
 
 /// One side's document, parsed and with every image reference resolved
 /// against that side's own tree.
-fn load_side(location: &RepoLocation, source: Option<&DocSource>, path: &RepoPath) -> PreviewParse {
+fn load_side(
+    location: &RepoLocation,
+    source: Option<&DocSource>,
+    path: &RepoPath,
+    kind: DocumentKind,
+) -> PreviewParse {
     let bytes = source.and_then(|source| sourcefour_git::document_bytes(location, source));
-    let blocks = document_blocks(bytes.as_deref());
+    let parsed = document_blocks(kind, bytes.as_deref());
+    let (blocks, error) = match parsed {
+        Ok(blocks) => (blocks, None),
+        Err(error) => (Vec::new(), Some(error.to_string())),
+    };
     let mut images = HashMap::new();
     if let Some(source) = source {
         for reference in sourcefour_doc::image_sources(&blocks) {
@@ -377,7 +398,11 @@ fn load_side(location: &RepoLocation, source: Option<&DocSource>, path: &RepoPat
             });
         }
     }
-    PreviewParse { blocks, images }
+    PreviewParse {
+        blocks,
+        images,
+        error,
+    }
 }
 
 /// §12.5 preview probe; prints only under `SOURCEFOUR_FRAME_LOG`.
@@ -447,10 +472,12 @@ fn demo_parse() -> (PreviewParse, PreviewParse) {
         PreviewParse {
             blocks: sourcefour_doc::parse_markdown(crate::demo::PREVIEW_MARKDOWN_OLD),
             images: images.clone(),
+            error: None,
         },
         PreviewParse {
             blocks: sourcefour_doc::parse_markdown(&stress_body()),
             images,
+            error: None,
         },
     )
 }
@@ -509,7 +536,7 @@ fn span_run(
         font,
         color,
         background_color: span.code.then_some(theme.bg_list),
-        underline: span.link.is_some().then(|| gpui::UnderlineStyle {
+        underline: (span.underline || span.link.is_some()).then(|| gpui::UnderlineStyle {
             thickness: px(1.0),
             color: None,
             wavy: false,
@@ -601,11 +628,19 @@ fn index_at(layout: &gpui::TextLayout, text: &str, position: gpui::Point<gpui::P
 /// costs what is on screen rather than what the document holds.
 ///
 /// The pane's own id scopes every element id the blocks under it build.
-pub(super) fn pane(preview: &PreviewDoc, side: PreviewSide) -> gpui::Stateful<Div> {
-    div()
-        .id(side.pane_id())
-        .size_full()
-        .child(gpui::list(preview.list.clone()).size_full())
+pub(super) fn pane(preview: &PreviewDoc, side: PreviewSide, theme: &Theme) -> gpui::Stateful<Div> {
+    let pane = div().id(side.pane_id()).size_full();
+    if let Some(error) = &preview.error {
+        pane.flex()
+            .items_center()
+            .justify_center()
+            .p(px(24.0))
+            .text_size(px(12.0))
+            .text_color(theme.text_faint)
+            .child(format!("Unable to preview this RTF: {error}"))
+    } else {
+        pane.child(gpui::list(preview.list.clone()).size_full())
+    }
 }
 
 impl SourcefourWindow {
@@ -627,8 +662,10 @@ impl SourcefourWindow {
             // No repository to read from — the demo seeds its own preview, so
             // this only happens before discovery finishes.
             let absent = || PreviewParse {
-                blocks: document_blocks(None),
+                blocks: document_blocks(DocumentKind::Markdown, None)
+                    .expect("an absent side does not parse bytes"),
                 images: HashMap::new(),
+                error: None,
             };
             view.preview = Some(PreviewState {
                 old: PreviewDoc::new(absent(), PreviewSide::Old, cx),
@@ -1192,7 +1229,7 @@ impl SourcefourWindow {
 #[cfg(test)]
 mod tests {
     use gpui::{FontWeight, Hsla, TextRun};
-    use sourcefour_doc::{DocBlockKind, DocSpan};
+    use sourcefour_doc::{DocBlockKind, DocSpan, DocumentKind};
     use sourcefour_model::{DiffParent, DiffPaths, FileDiffRequest, Oid, RepoPath};
 
     use crate::theme::Theme;
@@ -1390,6 +1427,11 @@ mod tests {
                     strike: true,
                     ..DocSpan::default()
                 },
+                DocSpan {
+                    text: String::from("under"),
+                    underline: true,
+                    ..DocSpan::default()
+                },
             ],
             &gpui::font("Helvetica"),
             &MONO.into(),
@@ -1407,6 +1449,7 @@ mod tests {
         assert_eq!(runs[2].font.weight, FontWeight::SEMIBOLD);
         assert_eq!(runs[3].font.style, gpui::FontStyle::Italic);
         assert!(runs[3].strikethrough.is_some());
+        assert!(runs[4].underline.is_some());
     }
 
     #[test]
@@ -1467,7 +1510,7 @@ mod tests {
 
     #[test]
     fn a_side_without_the_document_renders_a_notice_rather_than_nothing() {
-        let blocks = document_blocks(None);
+        let blocks = document_blocks(DocumentKind::Markdown, None).unwrap();
 
         assert_eq!(blocks.len(), 1);
         assert_eq!(
@@ -1483,13 +1526,36 @@ mod tests {
 
     #[test]
     fn present_bytes_parse_as_the_document_they_are() {
-        let blocks = document_blocks(Some(b"# Title\n\ntext\n"));
+        let blocks = document_blocks(DocumentKind::Markdown, Some(b"# Title\n\ntext\n")).unwrap();
 
         assert_eq!(blocks.len(), 2);
         assert!(matches!(
             blocks[0].kind,
             DocBlockKind::Heading { level: 1, .. }
         ));
+    }
+
+    #[test]
+    fn rtf_bytes_use_the_rtf_parser() {
+        let blocks =
+            document_blocks(DocumentKind::Rtf, Some(br"{\rtf1\ansi Plain {\b bold}.}")).unwrap();
+
+        let DocBlockKind::Paragraph { spans } = &blocks[0].kind else {
+            panic!("RTF prose should become a paragraph");
+        };
+        assert_eq!(
+            spans
+                .iter()
+                .map(|span| span.text.as_str())
+                .collect::<String>(),
+            "Plain bold."
+        );
+        assert!(spans.iter().any(|span| span.bold && span.text == "bold"));
+    }
+
+    #[test]
+    fn malformed_rtf_is_a_parse_error() {
+        assert!(document_blocks(DocumentKind::Rtf, Some(br"{\rtf1 broken")).is_err());
     }
 
     #[test]

--- a/apps/sourcefour/src/views/preview.rs
+++ b/apps/sourcefour/src/views/preview.rs
@@ -20,7 +20,10 @@ use gpui::{
     Div, Font, FontWeight, Hsla, IntoElement, StatefulInteractiveElement, StyledText, TextRun,
     Window, div, prelude::*, px,
 };
-use sourcefour_doc::{CellAlignment, DocBlock, DocBlockKind, DocSpan, DocumentKind};
+use sourcefour_doc::{
+    CellAlignment, DocBlock, DocBlockKind, DocColor, DocSpan, DocumentKind, EmbeddedImageFormat,
+    EmbeddedMedia, ParagraphAlignment, ParagraphStyle,
+};
 use sourcefour_git::{DocSource, ImageResolution};
 use sourcefour_model::{DiffContent, RepoLocation, RepoPath};
 
@@ -524,10 +527,15 @@ fn span_run(
     if span.italic {
         font.style = gpui::FontStyle::Italic;
     }
+    if let Some(family) = &span.font_family {
+        font.family = family.clone().into();
+    }
     let color = if span.link.is_some() {
         theme.accent
     } else if span.code {
         theme.text_primary
+    } else if let Some(document_color) = span.foreground {
+        theme_adapted_foreground(document_color, theme)
     } else {
         color
     };
@@ -535,7 +543,10 @@ fn span_run(
         len: span.text.len(),
         font,
         color,
-        background_color: span.code.then_some(theme.bg_list),
+        background_color: span
+            .highlight
+            .map(|color| theme_adapted_highlight(color, theme))
+            .or_else(|| span.code.then_some(theme.bg_list)),
         underline: (span.underline || span.link.is_some()).then(|| gpui::UnderlineStyle {
             thickness: px(1.0),
             color: None,
@@ -545,6 +556,29 @@ fn span_run(
             thickness: px(1.0),
             color: None,
         }),
+    }
+}
+
+fn document_color(color: DocColor) -> Hsla {
+    gpui::rgb((u32::from(color.red) << 16) | (u32::from(color.green) << 8) | u32::from(color.blue))
+        .into()
+}
+
+fn theme_adapted_foreground(color: DocColor, theme: &Theme) -> Hsla {
+    let color = document_color(color);
+    if (color.l - theme.bg_list.l).abs() >= 0.28 {
+        color
+    } else {
+        theme.text_secondary
+    }
+}
+
+fn theme_adapted_highlight(color: DocColor, theme: &Theme) -> Hsla {
+    let color = document_color(color);
+    if (color.l - theme.bg_list.l).abs() >= 0.18 {
+        color.opacity(0.38)
+    } else {
+        theme.accent.opacity(0.24)
     }
 }
 
@@ -874,6 +908,9 @@ impl SourcefourWindow {
                 .mt(px(8.0))
                 .text_size(px(12.5))
                 .child(self.selectable_text(spans, font, self.theme.text_secondary, preview, id)),
+            DocBlockKind::RichParagraph { spans, style } => {
+                self.preview_rich_paragraph(spans, *style, font, preview, id)
+            }
             DocBlockKind::Code { text, .. } => self.preview_code(text, id),
             DocBlockKind::Quote { blocks } => div()
                 .mt(px(10.0))
@@ -893,6 +930,35 @@ impl SourcefourWindow {
                 .mb(px(4.0))
                 .h(px(1.0))
                 .bg(self.theme.border),
+            DocBlockKind::PageBreak => div()
+                .mt(px(16.0))
+                .mb(px(6.0))
+                .border_t_1()
+                .border_color(self.theme.border)
+                .pt(px(4.0))
+                .text_size(px(9.0))
+                .text_color(self.theme.text_faint)
+                .child("page break"),
+            DocBlockKind::Aside { label, blocks } => div()
+                .mt(px(10.0))
+                .p(px(10.0))
+                .rounded(px(5.0))
+                .border_1()
+                .border_color(self.theme.border)
+                .bg(self.theme.bg_chrome)
+                .child(
+                    div()
+                        .mb(px(4.0))
+                        .text_size(px(9.5))
+                        .text_color(self.theme.text_faint)
+                        .child(label.clone()),
+                )
+                .children(blocks.iter().enumerate().map(|(ordinal, block)| {
+                    self.preview_block(block, preview, font, id.child(ordinal))
+                })),
+            DocBlockKind::EmbeddedMedia { media, alt } => {
+                self.preview_embedded_media(media, alt, id)
+            }
             DocBlockKind::Image { src, alt } => self.preview_image(src, alt, preview, id),
             DocBlockKind::Table {
                 alignments,
@@ -900,6 +966,47 @@ impl SourcefourWindow {
                 rows,
             } => self.preview_table(alignments, header, rows, font, preview, id),
         }
+    }
+
+    fn preview_rich_paragraph(
+        &self,
+        spans: &[DocSpan],
+        style: ParagraphStyle,
+        font: &Font,
+        preview: &PreviewDoc,
+        id: BlockId,
+    ) -> Div {
+        let twips = |value: i32| {
+            let bounded = i16::try_from(value.clamp(0, 1080)).unwrap_or_default();
+            px(f32::from(bounded) / 15.0)
+        };
+        let dominant_size = spans
+            .iter()
+            .filter_map(|span| {
+                span.font_size_half_points
+                    .map(|size| (size, span.text.len()))
+            })
+            .fold(HashMap::<u16, usize>::new(), |mut counts, (size, len)| {
+                *counts.entry(size).or_default() += len;
+                counts
+            })
+            .into_iter()
+            .max_by_key(|(_, count)| *count)
+            .map_or(12.5, |(size, _)| (f32::from(size) / 2.0).clamp(9.0, 24.0));
+        div()
+            .mt(twips(style.space_before_twips.max(120)))
+            .mb(twips(style.space_after_twips))
+            .pl(twips(
+                style.left_indent_twips + style.first_line_indent_twips.max(0),
+            ))
+            .pr(twips(style.right_indent_twips))
+            .text_size(px(dominant_size))
+            .map(|paragraph| match style.alignment {
+                ParagraphAlignment::Center => paragraph.text_center(),
+                ParagraphAlignment::Right => paragraph.text_right(),
+                ParagraphAlignment::Left | ParagraphAlignment::Justify => paragraph.text_left(),
+            })
+            .child(self.selectable_text(spans, font, self.theme.text_secondary, preview, id))
     }
 
     /// A heading, sized by its level; the whole line carries the weight so a
@@ -1194,6 +1301,50 @@ impl SourcefourWindow {
                 .into_any_element(),
             _ => self
                 .preview_placeholder(format!("image not found · {src}"))
+                .into_any_element(),
+        };
+        div()
+            .mt(px(12.0))
+            .flex()
+            .flex_col()
+            .items_start()
+            .gap(px(4.0))
+            .child(body)
+            .children((!alt.is_empty()).then(|| {
+                div()
+                    .text_size(px(10.5))
+                    .text_color(self.theme.text_faint)
+                    .child(alt.to_owned())
+            }))
+    }
+
+    fn preview_embedded_media(&self, media: &EmbeddedMedia, alt: &str, id: BlockId) -> Div {
+        let body = match media {
+            EmbeddedMedia::Image { format, bytes } => {
+                let format = match format {
+                    EmbeddedImageFormat::Png => "png",
+                    EmbeddedImageFormat::Jpeg => "jpeg",
+                };
+                render_image(Some(bytes), format).map_or_else(
+                    || {
+                        self.preview_placeholder(String::from(
+                            "embedded image could not be decoded",
+                        ))
+                        .into_any_element()
+                    },
+                    |image| {
+                        gpui::img(image)
+                            .id(id.element("preview-embedded-image"))
+                            .max_w(px(CONTENT_WIDTH - 2.0 * CONTENT_PADDING))
+                            .max_h(px(IMAGE_HEIGHT))
+                            .object_fit(gpui::ObjectFit::Contain)
+                            .rounded(px(5.0))
+                            .into_any_element()
+                    },
+                )
+            }
+            EmbeddedMedia::Unsupported { label } => self
+                .preview_placeholder(format!("unsupported embedded content · {label}"))
                 .into_any_element(),
         };
         div()
@@ -1540,8 +1691,8 @@ mod tests {
         let blocks =
             document_blocks(DocumentKind::Rtf, Some(br"{\rtf1\ansi Plain {\b bold}.}")).unwrap();
 
-        let DocBlockKind::Paragraph { spans } = &blocks[0].kind else {
-            panic!("RTF prose should become a paragraph");
+        let DocBlockKind::RichParagraph { spans, .. } = &blocks[0].kind else {
+            panic!("RTF prose should become a rich paragraph");
         };
         assert_eq!(
             spans

--- a/apps/sourcefour/src/views/sidebar.rs
+++ b/apps/sourcefour/src/views/sidebar.rs
@@ -2,17 +2,19 @@
 //! branches, remotes, and Actions runs.
 
 use gpui::{
-    Div, FontWeight, IntoElement, Render, StatefulInteractiveElement, Window, div, prelude::*, px,
-    svg,
+    AnyView, App, Div, FontWeight, Hsla, IntoElement, Render, SharedString,
+    StatefulInteractiveElement, Window, div, prelude::*, px, svg,
 };
 use sourcefour_model::{
-    AheadBehindState, BranchSnapshot, HeadSnapshot, RepoSnapshot, WorktreeAccessibility,
+    AheadBehindState, BranchSnapshot, HeadSnapshot, RemoteBranchSnapshot, RepoSnapshot,
+    WorktreeAccessibility,
 };
 
 use std::collections::BTreeMap;
 
 use crate::{
     history::{is_scoped_to, toggled_scope},
+    icons::Icon,
     theme::Theme,
 };
 
@@ -67,30 +69,93 @@ struct SectionDragPreview {
     theme: Theme,
 }
 
-#[derive(Debug, Default)]
-struct BranchTree<'a> {
-    branch: Option<&'a BranchSnapshot>,
-    children: BTreeMap<&'a str, BranchTree<'a>>,
+struct SidebarTooltip {
+    text: SharedString,
+    palette: TooltipPalette,
+}
+
+#[derive(Clone, Copy)]
+struct TooltipPalette {
+    background: Hsla,
+    border: Hsla,
+    text: Hsla,
+}
+
+impl From<&Theme> for TooltipPalette {
+    fn from(theme: &Theme) -> Self {
+        Self {
+            background: theme.bg_chrome,
+            border: theme.border_strong,
+            text: theme.text_primary,
+        }
+    }
+}
+
+impl Render for SidebarTooltip {
+    fn render(&mut self, _window: &mut Window, _cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        div()
+            .px(px(8.0))
+            .py(px(5.0))
+            .rounded(px(5.0))
+            .border_1()
+            .border_color(self.palette.border)
+            .bg(self.palette.background)
+            .text_size(px(11.0))
+            .text_color(self.palette.text)
+            .shadow_md()
+            .child(self.text.clone())
+    }
+}
+
+fn sidebar_tooltip(
+    text: impl Into<SharedString>,
+    palette: TooltipPalette,
+    cx: &mut App,
+) -> AnyView {
+    let text = text.into();
+    cx.new(|_| SidebarTooltip { text, palette }).into()
+}
+
+#[derive(Debug)]
+struct RefTree<'a, T> {
+    item: Option<&'a T>,
+    children: BTreeMap<&'a str, RefTree<'a, T>>,
     path: String,
 }
 
-impl<'a> BranchTree<'a> {
+impl<T> Default for RefTree<'_, T> {
+    fn default() -> Self {
+        Self {
+            item: None,
+            children: BTreeMap::new(),
+            path: String::new(),
+        }
+    }
+}
+
+impl<'a, T> RefTree<'a, T> {
+    fn insert(&mut self, name: &'a str, item: &'a T) {
+        let mut node = self;
+        let mut path = String::new();
+        for segment in name.split('/') {
+            if !path.is_empty() {
+                path.push('/');
+            }
+            path.push_str(segment);
+            node = node.children.entry(segment).or_insert_with(|| Self {
+                path: path.clone(),
+                ..Self::default()
+            });
+        }
+        node.item = Some(item);
+    }
+}
+
+impl<'a> RefTree<'a, BranchSnapshot> {
     fn from_branches(branches: &'a [BranchSnapshot]) -> Self {
         let mut root = Self::default();
         for branch in branches {
-            let mut node = &mut root;
-            let mut path = String::new();
-            for segment in branch.short_name.split('/') {
-                if !path.is_empty() {
-                    path.push('/');
-                }
-                path.push_str(segment);
-                node = node.children.entry(segment).or_insert_with(|| Self {
-                    path: path.clone(),
-                    ..Self::default()
-                });
-            }
-            node.branch = Some(branch);
+            root.insert(&branch.short_name, branch);
         }
         root
     }
@@ -237,9 +302,9 @@ pub(super) fn head_label(head: &HeadSnapshot) -> String {
 
 fn disclosure(theme: &Theme, expanded: bool) -> Div {
     let path = if expanded {
-        "icons/chevron-down.svg"
+        Icon::ChevronDown
     } else {
-        "icons/chevron-right.svg"
+        Icon::ChevronRight
     };
     div()
         .size(px(12.0))
@@ -247,12 +312,17 @@ fn disclosure(theme: &Theme, expanded: bool) -> Div {
         .flex()
         .items_center()
         .justify_center()
-        .child(svg().path(path).size(px(10.0)).text_color(theme.text_faint))
+        .child(
+            svg()
+                .path(path.path())
+                .size(px(10.0))
+                .text_color(theme.text_faint),
+        )
 }
 
 fn branch_marker(theme: &Theme) -> gpui::Svg {
     svg()
-        .path("icons/git-branch.svg")
+        .path(Icon::GitBranch.path())
         .size(px(12.0))
         .flex_none()
         .text_color(theme.text_faint)
@@ -260,7 +330,7 @@ fn branch_marker(theme: &Theme) -> gpui::Svg {
 
 fn folder_marker(theme: &Theme) -> gpui::Svg {
     svg()
-        .path("icons/folder.svg")
+        .path(Icon::Folder.path())
         .size(px(12.0))
         .flex_none()
         .text_color(theme.text_faint)
@@ -270,10 +340,21 @@ fn branch_indent(depth: usize) -> f32 {
     15.0 + f32::from(u16::try_from(depth).unwrap_or(u16::MAX)) * 16.0
 }
 
+fn truncating_label(label: impl Into<SharedString>) -> Div {
+    div()
+        .flex_1()
+        .min_w(px(1.0))
+        .overflow_hidden()
+        .text_ellipsis()
+        .whitespace_nowrap()
+        .child(label.into())
+}
+
 fn remote_marker(theme: &Theme) -> gpui::Svg {
     svg()
-        .path("icons/globe.svg")
+        .path(Icon::Globe.path())
         .size(px(12.0))
+        .flex_none()
         .text_color(theme.orange)
 }
 
@@ -347,7 +428,7 @@ impl SourcefourWindow {
         snapshot: &RepoSnapshot,
         cx: &mut gpui::Context<Self>,
     ) -> gpui::Stateful<Div> {
-        let branch_tree = BranchTree::from_branches(&snapshot.local_branches);
+        let branch_tree = RefTree::from_branches(&snapshot.local_branches);
         let mut root = div()
             .w(px(self.panels.sidebar))
             .flex_none()
@@ -370,7 +451,7 @@ impl SourcefourWindow {
                             snapshot
                                 .worktrees
                                 .iter()
-                                .map(|tree| self.worktree_row(tree)),
+                                .map(|tree| self.worktree_row(tree, cx)),
                         )
                     }),
                 SidebarSection::Branches => root
@@ -383,17 +464,33 @@ impl SourcefourWindow {
                     .when(self.sections.expanded(section), |this| {
                         this.children(self.branch_tree_rows(&branch_tree, 0, cx))
                     }),
-                // The prototype counts remotes here, not their branches.
                 SidebarSection::Remotes => root
-                    .child(self.section("REMOTES", snapshot.remotes.len().to_string(), section, cx))
+                    .child(
+                        self.section(
+                            "REMOTES",
+                            snapshot
+                                .remotes
+                                .iter()
+                                .map(|remote| remote.branches.len())
+                                .sum::<usize>()
+                                .to_string(),
+                            section,
+                            cx,
+                        ),
+                    )
                     .when(self.sections.expanded(section), |this| {
                         this.children(snapshot.remotes.iter().flat_map(|remote| {
-                            std::iter::once(self.remote_row(remote)).chain(
-                                remote
-                                    .branches
-                                    .iter()
-                                    .map(|branch| self.remote_branch_row(&branch.short_name)),
-                            )
+                            let mut tree = RefTree::default();
+                            for branch in &remote.branches {
+                                let relative = branch
+                                    .short_name
+                                    .strip_prefix(&format!("{}/", remote.name))
+                                    .unwrap_or(&branch.short_name);
+                                tree.insert(relative, branch);
+                            }
+                            std::iter::once(self.remote_row(remote, cx).into_any_element())
+                                .chain(self.remote_tree_rows(&tree, &remote.name, 0, cx))
+                                .collect::<Vec<_>>()
                         }))
                     }),
                 // Only a GitHub repository has Actions to show.
@@ -417,14 +514,22 @@ impl SourcefourWindow {
         root
     }
 
-    pub(super) fn worktree_row(&self, tree: &sourcefour_model::WorktreeSnapshot) -> Div {
+    pub(super) fn worktree_row(
+        &self,
+        tree: &sourcefour_model::WorktreeSnapshot,
+        cx: &mut gpui::Context<Self>,
+    ) -> gpui::Stateful<Div> {
         let marker = match (&tree.accessibility, tree.is_current) {
             (WorktreeAccessibility::Inaccessible { .. }, _) => self.theme.red,
             (WorktreeAccessibility::Prunable { .. }, _) => self.theme.orange,
             (WorktreeAccessibility::Accessible, true) => self.theme.green,
             (WorktreeAccessibility::Accessible, false) => self.theme.text_faint,
         };
+        let path = tree.path.clone();
+        let activatable =
+            matches!(tree.accessibility, WorktreeAccessibility::Accessible) && !tree.is_current;
         div()
+            .id(gpui::SharedString::from(format!("worktree:{}", tree.id.0)))
             .h(px(47.0))
             .flex_none()
             .flex()
@@ -437,6 +542,13 @@ impl SourcefourWindow {
                 self.theme.bg_panel
             })
             .text_color(self.theme.text_primary)
+            .when(activatable, |row| {
+                row.cursor_pointer()
+                    .hover(|style| style.bg(self.theme.bg_hover))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.activate_worktree_path(path.clone(), cx);
+                    }))
+            })
             .child(
                 div()
                     .flex()
@@ -449,7 +561,7 @@ impl SourcefourWindow {
                             .flex()
                             .items_center()
                             .gap(px(6.0))
-                            .child(div().size(px(7.0)).rounded_full().bg(marker))
+                            .child(div().size(px(7.0)).flex_none().rounded_full().bg(marker))
                             .child(tree.display_name.clone())
                             .when(tree.is_locked, |this| {
                                 this.child(
@@ -501,6 +613,11 @@ impl SourcefourWindow {
     ) -> gpui::Stateful<Div> {
         let scoped = is_scoped_to(self.history.scope.as_ref(), &branch.full_name);
         let full_name = branch.full_name.clone();
+        let worktree_full_name = branch.full_name.clone();
+        let worktree_short_name = branch.short_name.clone();
+        let worktree_tooltip = format!("Create worktree from {}", branch.short_name);
+        let tooltip_palette = TooltipPalette::from(&self.theme);
+        let label = label.into();
         let tip = branch.tip;
         div()
             .id(gpui::SharedString::from(branch.full_name.clone()))
@@ -530,27 +647,62 @@ impl SourcefourWindow {
                 self.theme.text_secondary
             })
             .child(branch_marker(&self.theme))
-            .child(label.into())
+            .child(truncating_label(label))
             .children(self.pr_chip(&branch.short_name))
-            .child(div().flex_grow())
             .children(ahead_behind_text(branch.ahead_behind).map(|text| {
                 div()
+                    .flex_none()
                     .text_size(px(10.5))
                     .text_color(self.theme.accent)
                     .child(text)
             }))
+            .child(
+                div()
+                    .id(gpui::SharedString::from(format!(
+                        "add-worktree:{}",
+                        branch.full_name
+                    )))
+                    .size(px(20.0))
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(4.0))
+                    .cursor_pointer()
+                    .hover(|style| style.bg(self.theme.bg_hover))
+                    .tooltip(move |_, cx| {
+                        sidebar_tooltip(worktree_tooltip.clone(), tooltip_palette, cx)
+                    })
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        this.open_worktree_dialog(
+                            super::worktree_dialog::WorktreeDialogSource::Local {
+                                full_name: worktree_full_name.clone(),
+                                short_name: worktree_short_name.clone(),
+                            },
+                            window,
+                            cx,
+                        );
+                    }))
+                    .child(
+                        svg()
+                            .path(Icon::FolderPlus.path())
+                            .size(px(12.0))
+                            .text_color(self.theme.text_faint),
+                    ),
+            )
     }
 
     fn branch_tree_rows(
         &self,
-        tree: &BranchTree<'_>,
+        tree: &RefTree<'_, BranchSnapshot>,
         depth: usize,
         cx: &mut gpui::Context<Self>,
     ) -> Vec<gpui::AnyElement> {
         let mut rows = Vec::new();
         for (&segment, node) in &tree.children {
             if node.children.is_empty() {
-                if let Some(branch) = node.branch {
+                if let Some(branch) = node.item {
                     rows.push(
                         self.branch_row(branch, segment.to_owned(), depth, cx)
                             .into_any_element(),
@@ -567,7 +719,7 @@ impl SourcefourWindow {
             if !expanded {
                 continue;
             }
-            if let Some(branch) = node.branch {
+            if let Some(branch) = node.item {
                 rows.push(
                     self.branch_row(branch, branch.short_name.clone(), depth + 1, cx)
                         .into_any_element(),
@@ -603,7 +755,7 @@ impl SourcefourWindow {
             .text_color(self.theme.text_secondary)
             .child(disclosure(&self.theme, expanded))
             .child(folder_marker(&self.theme))
-            .child(label.to_owned())
+            .child(truncating_label(label.to_owned()))
             .on_click(cx.listener(move |this, _, _, cx| {
                 if !this.collapsed_branch_folders.remove(&path) {
                     this.collapsed_branch_folders.insert(path.clone());
@@ -613,8 +765,16 @@ impl SourcefourWindow {
             }))
     }
 
-    pub(super) fn remote_row(&self, remote: &sourcefour_model::RemoteSnapshot) -> Div {
+    pub(super) fn remote_row(
+        &self,
+        remote: &sourcefour_model::RemoteSnapshot,
+        cx: &mut gpui::Context<Self>,
+    ) -> gpui::Stateful<Div> {
+        let remote_name = remote.name.clone();
+        let tooltip = format!("Fetch {}", remote.name);
+        let tooltip_palette = TooltipPalette::from(&self.theme);
         div()
+            .id(gpui::SharedString::from(format!("remote:{}", remote.name)))
             .h(px(29.0))
             .flex_none()
             .flex()
@@ -625,26 +785,180 @@ impl SourcefourWindow {
             .font_weight(FontWeight::MEDIUM)
             .text_color(self.theme.orange)
             .child(remote_marker(&self.theme))
-            .child(remote.name.clone())
-            .child(div().flex_grow())
+            .child(truncating_label(remote.name.clone()).flex_initial())
             .children(remote.fetch_url.clone().map(|url| {
-                div()
+                truncating_label(url)
                     .text_size(px(10.0))
                     .text_color(self.theme.text_faint)
-                    .child(url)
             }))
+            .child(
+                div()
+                    .id(gpui::SharedString::from(format!("fetch:{}", remote.name)))
+                    .size(px(20.0))
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(4.0))
+                    .cursor_pointer()
+                    .hover(|style| style.bg(self.theme.bg_hover))
+                    .tooltip(move |_, cx| sidebar_tooltip(tooltip.clone(), tooltip_palette, cx))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.fetch_remote(remote_name.clone(), cx);
+                    }))
+                    .child(
+                        svg()
+                            .path(Icon::CloudDownload.path())
+                            .size(px(12.0))
+                            .text_color(self.theme.orange),
+                    ),
+            )
     }
 
-    pub(super) fn remote_branch_row(&self, short_name: &str) -> Div {
+    fn remote_tree_rows(
+        &self,
+        tree: &RefTree<'_, RemoteBranchSnapshot>,
+        remote: &str,
+        depth: usize,
+        cx: &mut gpui::Context<Self>,
+    ) -> Vec<gpui::AnyElement> {
+        let mut rows = Vec::new();
+        for (&segment, node) in &tree.children {
+            if node.children.is_empty() {
+                if let Some(branch) = node.item {
+                    rows.push(
+                        self.remote_branch_row(branch, segment, depth, cx)
+                            .into_any_element(),
+                    );
+                }
+                continue;
+            }
+            let key = format!("remote:{remote}:{}", node.path);
+            let expanded = !self.collapsed_branch_folders.contains(&key);
+            rows.push(
+                self.branch_folder_row(segment, &key, depth + 1, expanded, cx)
+                    .into_any_element(),
+            );
+            if !expanded {
+                continue;
+            }
+            if let Some(branch) = node.item {
+                rows.push(
+                    self.remote_branch_row(branch, &node.path, depth + 1, cx)
+                        .into_any_element(),
+                );
+            }
+            rows.extend(self.remote_tree_rows(node, remote, depth + 1, cx));
+        }
+        rows
+    }
+
+    pub(super) fn remote_branch_row(
+        &self,
+        branch: &RemoteBranchSnapshot,
+        label: &str,
+        depth: usize,
+        cx: &mut gpui::Context<Self>,
+    ) -> gpui::Stateful<Div> {
+        let scoped = is_scoped_to(self.history.scope.as_ref(), &branch.full_name);
+        let full_name = branch.full_name.clone();
+        let action_full_name = branch.full_name.clone();
+        let action_short_name = branch.short_name.clone();
+        let worktree_full_name = branch.full_name.clone();
+        let worktree_short_name = branch.short_name.clone();
+        let tracking_tip = format!("Use {} locally", branch.full_name);
+        let worktree_tip = format!("Create worktree from {}", branch.full_name);
+        let palette = TooltipPalette::from(&self.theme);
+        let tip = branch.tip;
         div()
+            .id(gpui::SharedString::from(branch.full_name.clone()))
             .h(px(24.0))
             .flex_none()
             .flex()
             .items_center()
-            .pl(px(34.0))
+            .pl(px(branch_indent(depth + 1)))
+            .pr(px(15.0))
+            .gap(px(7.0))
+            .cursor_pointer()
+            .hover(|style| style.bg(self.theme.bg_hover))
+            .on_click(cx.listener(move |this, _, _, cx| {
+                let scope = toggled_scope(this.history.scope.as_ref(), &full_name, tip);
+                this.start_history(scope, cx);
+                cx.notify();
+            }))
+            .bg(if scoped {
+                self.theme.bg_selected
+            } else {
+                self.theme.bg_panel
+            })
             .text_size(px(12.0))
             .text_color(self.theme.purple)
-            .child(short_name.to_owned())
+            .child(branch_marker(&self.theme))
+            .child(truncating_label(label.to_owned()))
+            .child(
+                div()
+                    .id(gpui::SharedString::from(format!(
+                        "track:{}",
+                        branch.full_name
+                    )))
+                    .size(px(20.0))
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(4.0))
+                    .cursor_pointer()
+                    .hover(|style| style.bg(self.theme.bg_hover))
+                    .tooltip(move |_, cx| sidebar_tooltip(tracking_tip.clone(), palette, cx))
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        this.use_remote_branch(
+                            action_full_name.clone(),
+                            action_short_name.clone(),
+                            window,
+                            cx,
+                        );
+                    }))
+                    .child(
+                        svg()
+                            .path(Icon::CloudDownload.path())
+                            .size(px(12.0))
+                            .text_color(self.theme.purple),
+                    ),
+            )
+            .child(
+                div()
+                    .id(gpui::SharedString::from(format!(
+                        "remote-worktree:{}",
+                        branch.full_name
+                    )))
+                    .size(px(20.0))
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(4.0))
+                    .cursor_pointer()
+                    .hover(|style| style.bg(self.theme.bg_hover))
+                    .tooltip(move |_, cx| sidebar_tooltip(worktree_tip.clone(), palette, cx))
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        this.open_worktree_dialog(
+                            super::worktree_dialog::WorktreeDialogSource::Remote {
+                                full_name: worktree_full_name.clone(),
+                                short_name: worktree_short_name.clone(),
+                            },
+                            window,
+                            cx,
+                        );
+                    }))
+                    .child(
+                        svg()
+                            .path(Icon::FolderPlus.path())
+                            .size(px(12.0))
+                            .text_color(self.theme.text_faint),
+                    ),
+            )
     }
 
     pub(super) fn loading_sidebar(&self, cx: &mut gpui::Context<Self>) -> Div {
@@ -711,7 +1025,7 @@ mod tests {
             branch("fix/crash"),
         ];
 
-        let tree = BranchTree::from_branches(&branches);
+        let tree = RefTree::from_branches(&branches);
         assert_eq!(
             tree.children.keys().copied().collect::<Vec<_>>(),
             ["feature", "fix", "main"]
@@ -732,18 +1046,49 @@ mod tests {
     fn a_branch_can_also_be_a_folder_prefix() {
         let branches = [branch("feature"), branch("feature/login")];
 
-        let tree = BranchTree::from_branches(&branches);
+        let tree = RefTree::from_branches(&branches);
         let feature = &tree.children["feature"];
 
         assert_eq!(
-            feature.branch.map(|branch| branch.short_name.as_str()),
+            feature.item.map(|branch| branch.short_name.as_str()),
             Some("feature")
         );
         assert_eq!(
             feature.children["login"]
-                .branch
+                .item
                 .map(|branch| branch.short_name.as_str()),
             Some("feature/login")
+        );
+    }
+
+    #[test]
+    fn remote_names_form_the_same_recursive_tree_without_the_remote_prefix() {
+        let branches = [
+            sourcefour_model::RemoteBranchSnapshot {
+                full_name: String::from("refs/remotes/origin/feature/auth/login"),
+                short_name: String::from("origin/feature/auth/login"),
+                tip: Oid::sha1([0; 20]),
+            },
+            sourcefour_model::RemoteBranchSnapshot {
+                full_name: String::from("refs/remotes/origin/fix/crash"),
+                short_name: String::from("origin/fix/crash"),
+                tip: Oid::sha1([1; 20]),
+            },
+        ];
+        let mut tree = RefTree::default();
+        for branch in &branches {
+            tree.insert(branch.short_name.strip_prefix("origin/").unwrap(), branch);
+        }
+        assert_eq!(
+            tree.children.keys().copied().collect::<Vec<_>>(),
+            ["feature", "fix"]
+        );
+        assert_eq!(
+            tree.children["feature"].children["auth"].children["login"]
+                .item
+                .unwrap()
+                .full_name,
+            "refs/remotes/origin/feature/auth/login"
         );
     }
 

--- a/apps/sourcefour/src/views/worktree_dialog.rs
+++ b/apps/sourcefour/src/views/worktree_dialog.rs
@@ -1,0 +1,406 @@
+//! Linked-worktree creation dialog and path suggestions.
+
+use std::path::{Path, PathBuf};
+
+use gpui::{FontWeight, IntoElement, Window, div, prelude::*, px};
+use sourcefour_model::{AddWorktreeRequest, OperationOutcome, WorktreeSource};
+
+use crate::settings::WorktreeLocation;
+
+use super::SourcefourWindow;
+
+#[derive(Clone)]
+pub(super) enum WorktreeDialogSource {
+    Local {
+        full_name: String,
+        short_name: String,
+    },
+    Remote {
+        full_name: String,
+        short_name: String,
+    },
+}
+
+pub(super) struct WorktreeDialog {
+    source: WorktreeDialogSource,
+    running: bool,
+    error: Option<String>,
+}
+
+fn safe_component(branch: &str) -> String {
+    let mut result = String::new();
+    let mut separator = false;
+    for character in branch.chars() {
+        if character.is_alphanumeric() || matches!(character, '.' | '_') {
+            result.push(character);
+            separator = false;
+        } else if !separator && !result.is_empty() {
+            result.push('-');
+            separator = true;
+        }
+    }
+    let result = result.trim_matches('-');
+    if result.is_empty() {
+        String::from("worktree")
+    } else {
+        result.to_owned()
+    }
+}
+
+fn unused_path(base: PathBuf) -> PathBuf {
+    if !base.exists() {
+        return base;
+    }
+    let parent = base.parent().unwrap_or_else(|| Path::new("."));
+    let name = base.file_name().map_or_else(
+        || String::from("worktree"),
+        |name| name.to_string_lossy().into_owned(),
+    );
+    (2..=u32::MAX)
+        .map(|number| parent.join(format!("{name}-{number}")))
+        .find(|path| !path.exists())
+        .unwrap_or(base)
+}
+
+impl SourcefourWindow {
+    fn suggested_worktree_path(&self, branch: &str) -> Option<PathBuf> {
+        let snapshot = self.snapshot()?;
+        let main = snapshot.worktrees.iter().find(|tree| tree.is_main)?;
+        let branch = safe_component(branch);
+        let suggested = match self.settings.git.worktree_location {
+            WorktreeLocation::Sibling => {
+                let parent = main.path.parent()?;
+                parent.join(format!("{}-{branch}", self.name))
+            }
+            WorktreeLocation::InsideRepository => main.path.join(".worktrees").join(branch),
+        };
+        Some(unused_path(suggested))
+    }
+
+    pub(super) fn open_worktree_dialog(
+        &mut self,
+        mut source: WorktreeDialogSource,
+        window: &mut Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let local_name = match &source {
+            WorktreeDialogSource::Local { short_name, .. } => Some(short_name.clone()),
+            WorktreeDialogSource::Remote { short_name, .. } => short_name
+                .split_once('/')
+                .map(|(_, branch)| branch.to_owned()),
+        };
+        if let Some(local) = local_name.as_deref().and_then(|name| {
+            self.snapshot()?
+                .local_branches
+                .iter()
+                .find(|branch| branch.short_name == name)
+                .cloned()
+        }) {
+            let matches_source = match &source {
+                WorktreeDialogSource::Local { .. } => true,
+                WorktreeDialogSource::Remote { full_name, .. } => local
+                    .upstream
+                    .as_ref()
+                    .is_some_and(|upstream| upstream.full_name == *full_name),
+            };
+            if matches_source {
+                if let Some(tree) = local.checked_out_in.and_then(|id| {
+                    self.snapshot()?
+                        .worktrees
+                        .iter()
+                        .find(|tree| tree.id == id)
+                        .cloned()
+                }) {
+                    self.activate_worktree_path(tree.path, cx);
+                    return;
+                }
+                source = WorktreeDialogSource::Local {
+                    full_name: local.full_name,
+                    short_name: local.short_name,
+                };
+            }
+        }
+        let local_name = match &source {
+            WorktreeDialogSource::Local { short_name, .. } => short_name.clone(),
+            WorktreeDialogSource::Remote { short_name, .. } => short_name
+                .split_once('/')
+                .map_or(short_name.as_str(), |(_, branch)| branch)
+                .to_owned(),
+        };
+        let Some(path) = self.suggested_worktree_path(&local_name) else {
+            return;
+        };
+        self.worktree_dialog = Some(WorktreeDialog {
+            source: source.clone(),
+            running: false,
+            error: None,
+        });
+        self.branch_input.update(cx, |input, cx| {
+            if matches!(source, WorktreeDialogSource::Remote { .. }) {
+                input.set_text(&local_name, cx);
+            }
+        });
+        self.worktree_path_input
+            .update(cx, |input, cx| input.set_text(&path.to_string_lossy(), cx));
+        self.worktree_path_input
+            .read(cx)
+            .focus_handle
+            .clone()
+            .focus(window);
+        cx.notify();
+    }
+
+    pub(super) fn close_worktree_dialog(
+        &mut self,
+        window: &mut Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        self.worktree_dialog = None;
+        self.focus.focus(window);
+        cx.notify();
+    }
+
+    pub(super) fn submit_worktree_dialog(
+        &mut self,
+        window: &mut Window,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let Some(location) = self.location.clone() else {
+            return;
+        };
+        let entered_text = self.worktree_path_input.read(cx).text().to_owned();
+        if entered_text.trim().is_empty() {
+            return;
+        }
+        let entered_path = PathBuf::from(entered_text);
+        let path = if entered_path.is_absolute() {
+            entered_path
+        } else {
+            location
+                .active_worktree_path
+                .as_deref()
+                .unwrap_or(&location.common_dir)
+                .join(entered_path)
+        };
+        let local_name = self.branch_input.read(cx).text().to_owned();
+        let worktree = self.active_worktree_id();
+        let internal = self.settings.git.worktree_location == WorktreeLocation::InsideRepository;
+        let Some(dialog) = &mut self.worktree_dialog else {
+            return;
+        };
+        if dialog.running || path.as_os_str().is_empty() {
+            return;
+        }
+        let source = match &dialog.source {
+            WorktreeDialogSource::Local { full_name, .. } => WorktreeSource::LocalBranch {
+                full_name: full_name.clone(),
+            },
+            WorktreeDialogSource::Remote { full_name, .. } => {
+                if !sourcefour_git::is_valid_branch_name(&local_name) {
+                    return;
+                }
+                WorktreeSource::RemoteBranch {
+                    full_name: full_name.clone(),
+                    local_name,
+                }
+            }
+        };
+        dialog.running = true;
+        dialog.error = None;
+        self.focus.focus(window);
+        let request = AddWorktreeRequest {
+            worktree,
+            source,
+            path: path.clone(),
+        };
+        cx.spawn(async move |this, cx| {
+            let outcome = cx
+                .background_executor()
+                .spawn(async move {
+                    if internal {
+                        sourcefour_git::ensure_internal_worktrees_excluded(&location).map_err(
+                            |error| {
+                                sourcefour_model::RepoFailure::new(
+                                    sourcefour_model::RepoFailureKind::PermissionDenied,
+                                    "Worktree directory could not be excluded",
+                                    "The repository-local exclude file could not be updated.",
+                                )
+                                .with_details(error.to_string())
+                            },
+                        )?;
+                    }
+                    sourcefour_git::add_worktree(&location, &request)
+                })
+                .await;
+            this.update(cx, |this, cx| {
+                match outcome {
+                    Ok(OperationOutcome::Succeeded { summary, .. }) => {
+                        this.worktree_dialog = None;
+                        this.op_status = Some((true, summary));
+                        this.activate_worktree_path(path, cx);
+                    }
+                    Ok(OperationOutcome::Failed { error, .. }) | Err(error) => {
+                        if let Some(dialog) = &mut this.worktree_dialog {
+                            dialog.running = false;
+                            dialog.error = Some(error.user.message);
+                        }
+                    }
+                    Ok(OperationOutcome::Cancelled { .. }) => this.worktree_dialog = None,
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+        cx.notify();
+    }
+
+    pub(super) fn worktree_overlay(
+        &self,
+        cx: &mut gpui::Context<Self>,
+    ) -> Option<impl IntoElement + use<>> {
+        let dialog = self.worktree_dialog.as_ref()?;
+        let remote = matches!(dialog.source, WorktreeDialogSource::Remote { .. });
+        let valid_branch =
+            !remote || sourcefour_git::is_valid_branch_name(self.branch_input.read(cx).text());
+        let creatable =
+            !dialog.running && valid_branch && !self.worktree_path_input.read(cx).text().is_empty();
+        Some(
+            super::modal_backdrop("worktree-overlay", &self.theme)
+                .items_center()
+                .justify_center()
+                .on_click(cx.listener(|this, _, window, cx| {
+                    this.close_worktree_dialog(window, cx);
+                }))
+                .child(
+                    super::modal_panel("worktree-panel", &self.theme)
+                        .w(px(460.0))
+                        .flex()
+                        .flex_col()
+                        .gap(px(10.0))
+                        .p(px(16.0))
+                        .child(
+                            div()
+                                .text_size(px(13.0))
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .text_color(self.theme.text_primary)
+                                .child("Create worktree"),
+                        )
+                        .when(remote, |panel| {
+                            panel.child(
+                                self.worktree_input_row("Local branch", self.branch_input.clone()),
+                            )
+                        })
+                        .child(self.worktree_input_row("Path", self.worktree_path_input.clone()))
+                        .children(dialog.error.clone().map(|error| {
+                            div()
+                                .text_size(px(11.0))
+                                .text_color(self.theme.red)
+                                .child(error)
+                        }))
+                        .child(
+                            div()
+                                .flex()
+                                .justify_end()
+                                .gap(px(8.0))
+                                .child(self.worktree_dialog_button(
+                                    "worktree-cancel",
+                                    "Cancel",
+                                    true,
+                                    cx,
+                                ))
+                                .child(self.worktree_dialog_button(
+                                    "worktree-create",
+                                    if dialog.running {
+                                        "Creating…"
+                                    } else {
+                                        "Create"
+                                    },
+                                    creatable,
+                                    cx,
+                                )),
+                        ),
+                ),
+        )
+    }
+
+    fn worktree_input_row(
+        &self,
+        label: &'static str,
+        input: gpui::Entity<crate::text_input::TextInput>,
+    ) -> gpui::Div {
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(5.0))
+            .text_size(px(10.5))
+            .text_color(self.theme.text_faint)
+            .child(label)
+            .child(
+                div()
+                    .h(px(30.0))
+                    .px(px(10.0))
+                    .flex()
+                    .items_center()
+                    .rounded(px(6.0))
+                    .border_1()
+                    .border_color(self.theme.border_strong)
+                    .bg(self.theme.bg_list)
+                    .text_color(self.theme.text_primary)
+                    .child(input),
+            )
+    }
+
+    fn worktree_dialog_button(
+        &self,
+        id: &'static str,
+        label: &'static str,
+        enabled: bool,
+        cx: &mut gpui::Context<Self>,
+    ) -> gpui::Stateful<gpui::Div> {
+        let create = id == "worktree-create";
+        div()
+            .id(id)
+            .px(px(12.0))
+            .py(px(5.0))
+            .rounded(px(6.0))
+            .text_size(px(11.5))
+            .bg(if create && enabled {
+                self.theme.accent
+            } else {
+                self.theme.bg_hover
+            })
+            .text_color(if create && enabled {
+                self.theme.text_on_accent
+            } else if enabled {
+                self.theme.text_secondary
+            } else {
+                self.theme.text_faint
+            })
+            .when(enabled, |button| {
+                button
+                    .cursor_pointer()
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        if create {
+                            this.submit_worktree_dialog(window, cx);
+                        } else {
+                            this.close_worktree_dialog(window, cx);
+                        }
+                    }))
+            })
+            .child(label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::safe_component;
+
+    #[test]
+    fn branch_names_become_single_safe_path_components() {
+        assert_eq!(safe_component("feature/a thing"), "feature-a-thing");
+        assert_eq!(safe_component("///fix///x///"), "fix-x");
+        assert_eq!(safe_component("føø/✨"), "føø");
+        assert_eq!(safe_component("✨"), "worktree");
+    }
+}

--- a/crates/sourcefour-doc/Cargo.toml
+++ b/crates/sourcefour-doc/Cargo.toml
@@ -8,7 +8,10 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+encoding_rs.workspace = true
 pulldown-cmark.workspace = true
+rtf-grimoire.workspace = true
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sourcefour-doc/src/lib.rs
+++ b/crates/sourcefour-doc/src/lib.rs
@@ -1,10 +1,12 @@
-//! Document model and Markdown parsing for the diff viewer's preview pane.
+//! Document model and parsing for the diff viewer's preview pane.
 //!
 //! The crate is pure: no GPUI, no gix, no I/O. Input is source text some other
 //! crate already read, output is an owned block tree a renderer walks.
 
 mod model;
 mod parse;
+mod rtf;
 
 pub use model::{CellAlignment, DocBlock, DocBlockKind, DocSpan, DocumentKind, image_sources};
 pub use parse::parse_markdown;
+pub use rtf::{DocumentParseError, parse_document, parse_rtf};

--- a/crates/sourcefour-doc/src/lib.rs
+++ b/crates/sourcefour-doc/src/lib.rs
@@ -7,6 +7,9 @@ mod model;
 mod parse;
 mod rtf;
 
-pub use model::{CellAlignment, DocBlock, DocBlockKind, DocSpan, DocumentKind, image_sources};
+pub use model::{
+    CellAlignment, DocBlock, DocBlockKind, DocColor, DocSpan, DocumentKind, EmbeddedImageFormat,
+    EmbeddedMedia, ParagraphAlignment, ParagraphStyle, VerticalPosition, image_sources,
+};
 pub use parse::parse_markdown;
 pub use rtf::{DocumentParseError, parse_document, parse_rtf};

--- a/crates/sourcefour-doc/src/model.rs
+++ b/crates/sourcefour-doc/src/model.rs
@@ -29,6 +29,13 @@ pub enum DocBlockKind {
         /// Paragraph text, split by style.
         spans: Vec<DocSpan>,
     },
+    /// A paragraph carrying layout metadata supplied by a rich-text format.
+    RichParagraph {
+        /// Paragraph text, split by style.
+        spans: Vec<DocSpan>,
+        /// Layout hints normalized for the preview renderer.
+        style: ParagraphStyle,
+    },
     /// Preformatted text, verbatim except for a stripped trailing newline.
     Code {
         /// Info-string language tag, `None` when untagged or indented.
@@ -50,6 +57,22 @@ pub enum DocBlockKind {
     },
     /// A thematic break.
     Rule,
+    /// A page or section boundary in a paginated source document.
+    PageBreak,
+    /// Secondary document content such as a header, footer, or footnote.
+    Aside {
+        /// Human-readable role of the content.
+        label: String,
+        /// Captured content in source order.
+        blocks: Vec<DocBlock>,
+    },
+    /// Media stored inside the document rather than referenced by path.
+    EmbeddedMedia {
+        /// Media payload, or a reason it cannot be displayed.
+        media: EmbeddedMedia,
+        /// Accessible fallback text.
+        alt: String,
+    },
     /// An image, always its own block even when written inside a paragraph.
     Image {
         /// Destination as written, already resolved for reference-style images.
@@ -70,6 +93,86 @@ pub enum DocBlockKind {
         /// may be shorter than `alignments`; the source decides.
         rows: Vec<Vec<Vec<DocSpan>>>,
     },
+}
+
+/// Paragraph layout retained from rich-text documents.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ParagraphStyle {
+    /// Horizontal text alignment.
+    pub alignment: ParagraphAlignment,
+    /// Left indentation in twips (1/1440 inch).
+    pub left_indent_twips: i32,
+    /// Right indentation in twips.
+    pub right_indent_twips: i32,
+    /// First-line indentation in twips; negative values are hanging indents.
+    pub first_line_indent_twips: i32,
+    /// Space before the paragraph in twips.
+    pub space_before_twips: i32,
+    /// Space after the paragraph in twips.
+    pub space_after_twips: i32,
+}
+
+/// Horizontal alignment requested by a rich-text paragraph.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ParagraphAlignment {
+    /// Leading-edge alignment.
+    #[default]
+    Left,
+    /// Centered text.
+    Center,
+    /// Trailing-edge alignment.
+    Right,
+    /// Justified text; renderers may normalize this to leading-edge alignment.
+    Justify,
+}
+
+/// An RGB color declared by a document.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DocColor {
+    /// Red channel.
+    pub red: u8,
+    /// Green channel.
+    pub green: u8,
+    /// Blue channel.
+    pub blue: u8,
+}
+
+/// Baseline semantics retained even when the renderer normalizes their size.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum VerticalPosition {
+    /// Ordinary baseline.
+    #[default]
+    Normal,
+    /// Superscript text.
+    Superscript,
+    /// Subscript text.
+    Subscript,
+}
+
+/// Media embedded in a rich-text document.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EmbeddedMedia {
+    /// A PNG or JPEG payload the renderer can draw.
+    Image {
+        /// Encoded image format.
+        format: EmbeddedImageFormat,
+        /// Encoded image bytes.
+        bytes: Vec<u8>,
+    },
+    /// An object that is valid RTF but unsupported by the preview.
+    Unsupported {
+        /// Short format or failure description.
+        label: String,
+    },
+}
+
+/// Embedded raster formats GPUI can decode directly.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EmbeddedImageFormat {
+    /// Portable Network Graphics.
+    Png,
+    /// JPEG image.
+    Jpeg,
 }
 
 /// One table column's alignment, from the delimiter row.
@@ -111,6 +214,18 @@ pub struct DocSpan {
     pub underline: bool,
     /// Link destination when the run is part of a link.
     pub link: Option<String>,
+    /// Document foreground color, adapted for contrast by the renderer.
+    pub foreground: Option<DocColor>,
+    /// Document highlight color, adapted for contrast by the renderer.
+    pub highlight: Option<DocColor>,
+    /// Font family declared by the document.
+    pub font_family: Option<String>,
+    /// Source font size in half-points; used to choose a paragraph's dominant size.
+    pub font_size_half_points: Option<u16>,
+    /// Small-caps semantics.
+    pub small_caps: bool,
+    /// Superscript/subscript semantics.
+    pub vertical: VerticalPosition,
 }
 
 /// A markup language Sourcefour recognises by file extension.
@@ -159,7 +274,9 @@ fn collect_image_sources<'a>(blocks: &'a [DocBlock], sources: &mut Vec<&'a str>)
     for block in blocks {
         match &block.kind {
             DocBlockKind::Image { src, .. } => sources.push(src),
-            DocBlockKind::Quote { blocks } => collect_image_sources(blocks, sources),
+            DocBlockKind::Quote { blocks } | DocBlockKind::Aside { blocks, .. } => {
+                collect_image_sources(blocks, sources);
+            }
             DocBlockKind::List { items, .. } => {
                 for item in items {
                     collect_image_sources(item, sources);
@@ -168,9 +285,12 @@ fn collect_image_sources<'a>(blocks: &'a [DocBlock], sources: &mut Vec<&'a str>)
             // A table cell holds spans, and a span cannot be an image.
             DocBlockKind::Heading { .. }
             | DocBlockKind::Paragraph { .. }
+            | DocBlockKind::RichParagraph { .. }
             | DocBlockKind::Code { .. }
             | DocBlockKind::Table { .. }
-            | DocBlockKind::Rule => {}
+            | DocBlockKind::Rule
+            | DocBlockKind::PageBreak
+            | DocBlockKind::EmbeddedMedia { .. } => {}
         }
     }
 }

--- a/crates/sourcefour-doc/src/model.rs
+++ b/crates/sourcefour-doc/src/model.rs
@@ -89,7 +89,7 @@ pub enum CellAlignment {
 /// One styled text run inside a block.
 ///
 /// Runs are maximal: adjacent text sharing every attribute is one span.
-// Four flags mirror the four inline marks Markdown carries; a bitflag set would
+// Five flags mirror the inline marks the supported formats carry; a bitflag set would
 // only move the cost to the renderer.
 #[expect(
     clippy::struct_excessive_bools,
@@ -107,6 +107,8 @@ pub struct DocSpan {
     pub code: bool,
     /// Strikethrough.
     pub strike: bool,
+    /// Underline, independent of link decoration.
+    pub underline: bool,
     /// Link destination when the run is part of a link.
     pub link: Option<String>,
 }
@@ -116,6 +118,8 @@ pub struct DocSpan {
 pub enum DocumentKind {
     /// `CommonMark` plus strikethrough and tables.
     Markdown,
+    /// Rich Text Format.
+    Rtf,
     /// `AsciiDoc`, detected but not yet rendered.
     AsciiDoc,
     /// `LaTeX`, detected but not yet rendered.
@@ -135,6 +139,7 @@ impl DocumentKind {
         let dot = name.iter().rposition(|byte| *byte == b'.')?;
         match name.get(dot + 1..)?.to_ascii_lowercase().as_slice() {
             b"md" | b"markdown" | b"mdown" => Some(Self::Markdown),
+            b"rtf" => Some(Self::Rtf),
             b"adoc" | b"asciidoc" => Some(Self::AsciiDoc),
             b"tex" => Some(Self::Latex),
             _ => None,
@@ -189,10 +194,13 @@ mod tests {
 
     #[test]
     fn detect_reads_the_extension_case_insensitively() {
-        let cases: [(&[u8], Option<DocumentKind>); 11] = [
+        let cases: [(&[u8], Option<DocumentKind>); 14] = [
             (b"README.md", Some(DocumentKind::Markdown)),
             (b"docs/GUIDE.MARKDOWN", Some(DocumentKind::Markdown)),
             (b"notes.mdown", Some(DocumentKind::Markdown)),
+            (b"notes.rtf", Some(DocumentKind::Rtf)),
+            (b"NOTES.RTF", Some(DocumentKind::Rtf)),
+            (b"notes.rtfd", None),
             (b"book.AdOc", Some(DocumentKind::AsciiDoc)),
             (b"book.asciidoc", Some(DocumentKind::AsciiDoc)),
             (b"paper.TeX", Some(DocumentKind::Latex)),

--- a/crates/sourcefour-doc/src/parse.rs
+++ b/crates/sourcefour-doc/src/parse.rs
@@ -337,6 +337,7 @@ impl Builder {
             italic: style.italic,
             code,
             strike: style.strike,
+            underline: false,
             link: style.link,
         });
     }

--- a/crates/sourcefour-doc/src/parse.rs
+++ b/crates/sourcefour-doc/src/parse.rs
@@ -339,6 +339,7 @@ impl Builder {
             strike: style.strike,
             underline: false,
             link: style.link,
+            ..DocSpan::default()
         });
     }
 
@@ -461,7 +462,9 @@ mod tests {
     /// Concatenates a block's text, ignoring style.
     fn plain(block: &DocBlock) -> String {
         match &block.kind {
-            DocBlockKind::Heading { spans, .. } | DocBlockKind::Paragraph { spans } => {
+            DocBlockKind::Heading { spans, .. }
+            | DocBlockKind::Paragraph { spans }
+            | DocBlockKind::RichParagraph { spans, .. } => {
                 spans.iter().map(|span| span.text.as_str()).collect()
             }
             DocBlockKind::Code { text, .. } => text.clone(),
@@ -469,6 +472,9 @@ mod tests {
             | DocBlockKind::List { .. }
             | DocBlockKind::Table { .. }
             | DocBlockKind::Rule
+            | DocBlockKind::PageBreak
+            | DocBlockKind::Aside { .. }
+            | DocBlockKind::EmbeddedMedia { .. }
             | DocBlockKind::Image { .. } => String::new(),
         }
     }

--- a/crates/sourcefour-doc/src/rtf.rs
+++ b/crates/sourcefour-doc/src/rtf.rs
@@ -1,0 +1,685 @@
+//! A deliberately narrow RTF interpreter for readable diff previews.
+
+use encoding_rs::{Encoding, WINDOWS_1252};
+use rtf_grimoire::tokenizer::{Token, read_token};
+
+use crate::{DocBlock, DocBlockKind, DocSpan, DocumentKind, parse_markdown};
+
+/// Why document bytes could not be converted into preview blocks.
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum DocumentParseError {
+    /// The requested document kind is recognised but has no preview parser.
+    #[error("{0:?} preview is not implemented")]
+    Unsupported(DocumentKind),
+    /// The RTF token stream is malformed.
+    #[error("invalid RTF near byte {offset}")]
+    InvalidRtf {
+        /// Byte offset at which tokenization stopped.
+        offset: usize,
+    },
+    /// The input did not declare an RTF document at its root.
+    #[error("missing RTF document header")]
+    MissingHeader,
+    /// A closing group had no corresponding opening group.
+    #[error("unbalanced RTF group near byte {offset}")]
+    UnbalancedGroup {
+        /// Byte offset of the unmatched group boundary.
+        offset: usize,
+    },
+}
+
+/// Parses document bytes according to their detected kind.
+///
+/// # Errors
+///
+/// Returns an error when the kind has no parser or RTF input is malformed.
+pub fn parse_document(
+    kind: DocumentKind,
+    bytes: &[u8],
+) -> Result<Vec<DocBlock>, DocumentParseError> {
+    match kind {
+        DocumentKind::Markdown => Ok(parse_markdown(&String::from_utf8_lossy(bytes))),
+        DocumentKind::Rtf => parse_rtf(bytes),
+        DocumentKind::AsciiDoc | DocumentKind::Latex => Err(DocumentParseError::Unsupported(kind)),
+    }
+}
+
+/// Parses RTF into the normalized block tree used by the preview renderer.
+///
+/// # Errors
+///
+/// Returns an error when the token stream is malformed, has unbalanced groups,
+/// or does not declare an RTF document at its root.
+pub fn parse_rtf(bytes: &[u8]) -> Result<Vec<DocBlock>, DocumentParseError> {
+    let mut interpreter = Interpreter::default();
+    let mut remaining = bytes;
+
+    while !remaining.is_empty() {
+        let offset = bytes.len() - remaining.len();
+        let (next, token) =
+            read_token(remaining).map_err(|_| DocumentParseError::InvalidRtf { offset })?;
+        if next.len() == remaining.len() {
+            return Err(DocumentParseError::InvalidRtf { offset });
+        }
+        let end = bytes.len() - next.len();
+        interpreter.token(token, offset, end)?;
+        remaining = next;
+    }
+
+    interpreter.finish(bytes.len())
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "one flag per normalized inline mark"
+)]
+struct Style {
+    bold: bool,
+    italic: bool,
+    underline: bool,
+    strike: bool,
+    link: Option<String>,
+}
+
+impl Style {
+    fn span(&self, text: String) -> DocSpan {
+        DocSpan {
+            text,
+            bold: self.bold,
+            italic: self.italic,
+            code: false,
+            strike: self.strike,
+            underline: self.underline,
+            link: self.link.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+enum GroupKind {
+    #[default]
+    Normal,
+    Field {
+        url: Option<String>,
+    },
+    FieldInstruction {
+        text: String,
+    },
+    FieldResult,
+}
+
+#[derive(Clone, Debug)]
+struct GroupState {
+    style: Style,
+    unicode_fallback: usize,
+    skip: bool,
+    at_start: bool,
+    starred: bool,
+    kind: GroupKind,
+}
+
+impl Default for GroupState {
+    fn default() -> Self {
+        Self {
+            style: Style::default(),
+            unicode_fallback: 1,
+            skip: false,
+            at_start: true,
+            starred: false,
+            kind: GroupKind::Normal,
+        }
+    }
+}
+
+#[derive(Default)]
+struct Interpreter {
+    groups: Vec<GroupState>,
+    blocks: Vec<DocBlock>,
+    spans: Vec<DocSpan>,
+    paragraph_start: Option<usize>,
+    paragraph_end: usize,
+    code_page: u16,
+    fallback_remaining: usize,
+    pending_surrogate: Option<u16>,
+    hex_bytes: Vec<u8>,
+    hex_start: usize,
+    hex_end: usize,
+    hex_style: Option<Style>,
+    saw_header: bool,
+}
+
+impl Interpreter {
+    fn token(&mut self, token: Token, start: usize, end: usize) -> Result<(), DocumentParseError> {
+        if !matches!(token, Token::ControlWord { ref name, .. } if name == "'") {
+            self.flush_hex();
+        }
+
+        match token {
+            Token::StartGroup => self.start_group(),
+            Token::EndGroup => self.end_group(start)?,
+            Token::Newline(_) | Token::ControlBin(_) => {}
+            Token::ControlSymbol(symbol) => self.control_symbol(symbol, start, end),
+            Token::ControlWord { name, arg } => self.control_word(&name, arg, start, end),
+            Token::Text(bytes) => self.text(&bytes, start, end),
+        }
+        Ok(())
+    }
+
+    fn start_group(&mut self) {
+        let inherited = self.groups.last().cloned().unwrap_or_default();
+        self.groups.push(GroupState {
+            at_start: true,
+            starred: false,
+            kind: GroupKind::Normal,
+            ..inherited
+        });
+    }
+
+    fn end_group(&mut self, offset: usize) -> Result<(), DocumentParseError> {
+        self.flush_pending_surrogate(offset);
+        let ended = self
+            .groups
+            .pop()
+            .ok_or(DocumentParseError::UnbalancedGroup { offset })?;
+        if let GroupKind::FieldInstruction { text } = ended.kind
+            && let Some(field) = self
+                .groups
+                .iter_mut()
+                .rev()
+                .find(|group| matches!(group.kind, GroupKind::Field { .. }))
+            && let GroupKind::Field { url } = &mut field.kind
+        {
+            *url = hyperlink_target(&text);
+        }
+        Ok(())
+    }
+
+    fn control_symbol(&mut self, symbol: char, start: usize, end: usize) {
+        let Some(group) = self.groups.last_mut() else {
+            return;
+        };
+        if symbol == '*' && group.at_start {
+            group.starred = true;
+            return;
+        }
+        group.at_start = false;
+        if group.skip {
+            return;
+        }
+        let text = match symbol {
+            '\\' => "\\",
+            '{' => "{",
+            '}' => "}",
+            '~' => "\u{a0}",
+            '_' => "\u{2011}",
+            '-' => "",
+            _ => return,
+        };
+        self.emit(text, start, end);
+    }
+
+    fn control_word(&mut self, name: &str, arg: Option<i32>, start: usize, end: usize) {
+        if name == "'" {
+            self.hex(arg, start, end);
+            return;
+        }
+
+        let at_start = self.groups.last().is_some_and(|group| group.at_start);
+        if name == "rtf" && self.groups.len() == 1 && at_start {
+            self.saw_header = true;
+        }
+        if at_start {
+            self.open_destination(name);
+        }
+        let Some(group) = self.groups.last_mut() else {
+            return;
+        };
+        group.at_start = false;
+        if group.skip {
+            return;
+        }
+
+        if matches!(group.kind, GroupKind::FieldInstruction { .. }) {
+            return;
+        }
+
+        match name {
+            "ansi" => self.code_page = 1252,
+            "mac" => self.code_page = 10_000,
+            "ansicpg" => {
+                self.code_page = arg
+                    .and_then(|value| u16::try_from(value).ok())
+                    .unwrap_or(1252);
+            }
+            "b" => group.style.bold = enabled(arg),
+            "i" => group.style.italic = enabled(arg),
+            "ul" | "uld" | "uldash" | "uldashd" | "uldashdd" | "uldb" | "ulth" | "ulw" => {
+                group.style.underline = enabled(arg);
+            }
+            "ulnone" => group.style.underline = false,
+            "strike" => group.style.strike = enabled(arg),
+            "plain" => {
+                let link = group.style.link.take();
+                group.style = Style {
+                    link,
+                    ..Style::default()
+                };
+            }
+            "uc" => {
+                group.unicode_fallback = arg
+                    .and_then(|value| usize::try_from(value).ok())
+                    .unwrap_or(1);
+            }
+            "u" => self.unicode(arg, start, end),
+            "par" => self.flush_paragraph(end),
+            "line" => self.emit("\n", start, end),
+            "tab" => self.emit("\t", start, end),
+            "emdash" => self.emit("—", start, end),
+            "endash" => self.emit("–", start, end),
+            "bullet" => self.emit("•", start, end),
+            "lquote" => self.emit("‘", start, end),
+            "rquote" => self.emit("’", start, end),
+            "ldblquote" => self.emit("“", start, end),
+            "rdblquote" => self.emit("”", start, end),
+            _ => {}
+        }
+    }
+
+    fn open_destination(&mut self, name: &str) {
+        let field_url = if name == "fldrslt" {
+            self.groups
+                .iter()
+                .rev()
+                .find_map(|group| match &group.kind {
+                    GroupKind::Field { url } => url.clone(),
+                    GroupKind::Normal
+                    | GroupKind::FieldInstruction { .. }
+                    | GroupKind::FieldResult => None,
+                })
+        } else {
+            None
+        };
+        let Some(group) = self.groups.last_mut() else {
+            return;
+        };
+        match name {
+            "field" => group.kind = GroupKind::Field { url: None },
+            "fldinst" => {
+                group.kind = GroupKind::FieldInstruction {
+                    text: String::new(),
+                }
+            }
+            "fldrslt" => {
+                group.kind = GroupKind::FieldResult;
+                group.style.link = field_url;
+            }
+            name if group.starred || ignored_destination(name) => group.skip = true,
+            _ => {}
+        }
+    }
+
+    fn text(&mut self, bytes: &[u8], start: usize, end: usize) {
+        let Some(group) = self.groups.last() else {
+            return;
+        };
+        if group.skip {
+            return;
+        }
+        let skip = self.fallback_remaining.min(bytes.len());
+        self.fallback_remaining -= skip;
+        let bytes = &bytes[skip..];
+        if bytes.is_empty() {
+            return;
+        }
+        let decoded = decode(bytes, self.code_page);
+        if let Some(GroupState {
+            kind: GroupKind::FieldInstruction { text },
+            ..
+        }) = self.groups.last_mut()
+        {
+            text.push_str(&decoded);
+        } else {
+            self.flush_pending_surrogate(start);
+            self.emit(&decoded, start + skip, end);
+        }
+    }
+
+    fn hex(&mut self, arg: Option<i32>, start: usize, end: usize) {
+        if self.groups.last().is_none_or(|group| group.skip) {
+            return;
+        }
+        if self.fallback_remaining > 0 {
+            self.fallback_remaining -= 1;
+            return;
+        }
+        let Some(byte) = arg.and_then(|value| u8::try_from(value).ok()) else {
+            return;
+        };
+        let style = self.groups.last().map(|group| group.style.clone());
+        if !self.hex_bytes.is_empty() && self.hex_style != style {
+            self.flush_hex();
+        }
+        if self.hex_bytes.is_empty() {
+            self.hex_start = start;
+            self.hex_style = style;
+        }
+        self.hex_end = end;
+        self.hex_bytes.push(byte);
+    }
+
+    fn flush_hex(&mut self) {
+        if self.hex_bytes.is_empty() {
+            return;
+        }
+        let decoded = decode(&self.hex_bytes, self.code_page);
+        self.hex_bytes.clear();
+        if let Some(GroupState {
+            kind: GroupKind::FieldInstruction { text },
+            ..
+        }) = self.groups.last_mut()
+        {
+            text.push_str(&decoded);
+        } else {
+            let style = self.hex_style.take();
+            self.emit_with_style(&decoded, self.hex_start, self.hex_end, style);
+        }
+    }
+
+    fn unicode(&mut self, arg: Option<i32>, start: usize, end: usize) {
+        let Some(value) = arg else {
+            return;
+        };
+        let Ok(unit) = i16::try_from(value).map(i16::cast_unsigned) else {
+            return;
+        };
+        self.fallback_remaining = self.groups.last().map_or(1, |group| group.unicode_fallback);
+        if (0xD800..=0xDBFF).contains(&unit) {
+            self.flush_pending_surrogate(start);
+            self.pending_surrogate = Some(unit);
+        } else if (0xDC00..=0xDFFF).contains(&unit) {
+            if let Some(high) = self.pending_surrogate.take() {
+                let scalar = 0x1_0000 + (u32::from(high - 0xD800) << 10) + u32::from(unit - 0xDC00);
+                if let Some(character) = char::from_u32(scalar) {
+                    self.emit(&character.to_string(), start, end);
+                }
+            } else {
+                self.emit("�", start, end);
+            }
+        } else {
+            self.flush_pending_surrogate(start);
+            if let Some(character) = char::from_u32(u32::from(unit)) {
+                self.emit(&character.to_string(), start, end);
+            }
+        }
+    }
+
+    fn flush_pending_surrogate(&mut self, offset: usize) {
+        if self.pending_surrogate.take().is_some() {
+            self.emit("�", offset, offset);
+        }
+    }
+
+    fn emit(&mut self, text: &str, start: usize, end: usize) {
+        let style = self.groups.last().map(|group| group.style.clone());
+        self.emit_with_style(text, start, end, style);
+    }
+
+    fn emit_with_style(&mut self, text: &str, start: usize, end: usize, style: Option<Style>) {
+        if text.is_empty() {
+            return;
+        }
+        let style = style.unwrap_or_default();
+        self.paragraph_start.get_or_insert(start);
+        self.paragraph_end = self.paragraph_end.max(end);
+        if let Some(last) = self.spans.last_mut()
+            && last.bold == style.bold
+            && last.italic == style.italic
+            && last.underline == style.underline
+            && last.strike == style.strike
+            && last.link == style.link
+        {
+            last.text.push_str(text);
+        } else {
+            self.spans.push(style.span(text.to_owned()));
+        }
+    }
+
+    fn flush_paragraph(&mut self, end: usize) {
+        self.flush_pending_surrogate(end);
+        if self.spans.is_empty() {
+            return;
+        }
+        let start = self.paragraph_start.take().unwrap_or(end);
+        self.blocks.push(DocBlock {
+            kind: DocBlockKind::Paragraph {
+                spans: std::mem::take(&mut self.spans),
+            },
+            source_range: start..end.max(self.paragraph_end),
+        });
+        self.paragraph_end = 0;
+    }
+
+    fn finish(mut self, offset: usize) -> Result<Vec<DocBlock>, DocumentParseError> {
+        self.flush_hex();
+        self.flush_pending_surrogate(offset);
+        if !self.groups.is_empty() {
+            return Err(DocumentParseError::UnbalancedGroup { offset });
+        }
+        if !self.saw_header {
+            return Err(DocumentParseError::MissingHeader);
+        }
+        self.flush_paragraph(offset);
+        Ok(self.blocks)
+    }
+}
+
+fn enabled(arg: Option<i32>) -> bool {
+    arg != Some(0)
+}
+
+fn ignored_destination(name: &str) -> bool {
+    matches!(
+        name,
+        "fonttbl"
+            | "colortbl"
+            | "stylesheet"
+            | "info"
+            | "pict"
+            | "object"
+            | "objdata"
+            | "header"
+            | "headerl"
+            | "headerr"
+            | "footer"
+            | "footerl"
+            | "footerr"
+            | "footnote"
+            | "annotation"
+            | "datastore"
+            | "themedata"
+            | "colorschememapping"
+            | "generator"
+            | "listtable"
+            | "listoverridetable"
+            | "revtbl"
+            | "rsidtbl"
+            | "xmlnstbl"
+            | "mmathpr"
+            | "shp"
+            | "shpinst"
+            | "shprslt"
+            | "nonshppict"
+    )
+}
+
+fn encoding(code_page: u16) -> &'static Encoding {
+    match code_page {
+        65001 => encoding_rs::UTF_8,
+        1250 => encoding_rs::WINDOWS_1250,
+        1251 => encoding_rs::WINDOWS_1251,
+        1252 => encoding_rs::WINDOWS_1252,
+        1253 => encoding_rs::WINDOWS_1253,
+        1254 => encoding_rs::WINDOWS_1254,
+        1255 => encoding_rs::WINDOWS_1255,
+        1256 => encoding_rs::WINDOWS_1256,
+        932 => encoding_rs::SHIFT_JIS,
+        936 => encoding_rs::GBK,
+        949 => encoding_rs::EUC_KR,
+        950 => encoding_rs::BIG5,
+        10_000 => encoding_rs::MACINTOSH,
+        _ => WINDOWS_1252,
+    }
+}
+
+fn decode(bytes: &[u8], code_page: u16) -> String {
+    let (text, _, _) = encoding(code_page).decode(bytes);
+    text.into_owned()
+}
+
+fn hyperlink_target(instruction: &str) -> Option<String> {
+    let instruction = instruction.trim();
+    let rest = instruction.strip_prefix("HYPERLINK")?.trim_start();
+    if let Some(quoted) = rest.strip_prefix('"') {
+        let end = quoted.find('"')?;
+        Some(quoted[..end].to_owned())
+    } else {
+        rest.split_whitespace()
+            .next()
+            .filter(|url| !url.is_empty())
+            .map(str::to_owned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DocumentParseError, parse_rtf};
+    use crate::{DocBlock, DocBlockKind, DocSpan};
+
+    fn paragraphs(input: &[u8]) -> Result<Vec<Vec<DocSpan>>, DocumentParseError> {
+        parse_rtf(input).map(|blocks| {
+            blocks
+                .into_iter()
+                .filter_map(|block| match block.kind {
+                    DocBlockKind::Paragraph { spans } => Some(spans),
+                    _ => None,
+                })
+                .collect()
+        })
+    }
+
+    #[test]
+    fn parses_paragraphs_and_nested_styles() {
+        let parsed =
+            paragraphs(br"{\rtf1\ansi One {\b bold {\i both} bold} plain\par Two}").unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(
+            parsed[0]
+                .iter()
+                .map(|span| span.text.as_str())
+                .collect::<String>(),
+            "One bold both bold plain"
+        );
+        assert!(parsed[0][1].bold);
+        assert!(parsed[0][2].bold && parsed[0][2].italic);
+        assert!(parsed[0][3].bold);
+        assert_eq!(parsed[1][0].text, "Two");
+    }
+
+    #[test]
+    fn parses_underlining_strike_and_special_characters() {
+        let parsed =
+            paragraphs(br"{\rtf1 {\ul under}\tab {\strike struck}\line x\emdash y}").unwrap();
+        assert!(parsed[0][0].underline);
+        assert!(
+            parsed[0]
+                .iter()
+                .any(|span| span.strike && span.text == "struck")
+        );
+        let text = parsed[0]
+            .iter()
+            .map(|span| span.text.as_str())
+            .collect::<String>();
+        assert_eq!(text, "under\tstruck\nx—y");
+    }
+
+    #[test]
+    fn parses_unicode_fallback_surrogates_and_code_pages() {
+        let parsed =
+            paragraphs(br"{\rtf1\ansi\ansicpg1252 caf\'e9 \uc1\u8212? \u-10179?\u-8704?}").unwrap();
+        let text = parsed[0]
+            .iter()
+            .map(|span| span.text.as_str())
+            .collect::<String>();
+        assert_eq!(text, "café — 😀");
+    }
+
+    #[test]
+    fn parses_hyperlink_result_and_skips_instruction() {
+        let parsed = paragraphs(br#"{\rtf1 See {\field{\*\fldinst HYPERLINK "https://example.com"}{\fldrslt\plain example}}.}"#).unwrap();
+        assert_eq!(
+            parsed[0]
+                .iter()
+                .map(|span| span.text.as_str())
+                .collect::<String>(),
+            "See example."
+        );
+        assert_eq!(parsed[0][1].link.as_deref(), Some("https://example.com"));
+    }
+
+    #[test]
+    fn skips_metadata_pictures_objects_and_unknown_destinations() {
+        let parsed = paragraphs(
+            br"{\rtf1{\fonttbl hidden}{\pict 00ff}{\object nope}{\*\unknown secret}Visible}",
+        )
+        .unwrap();
+        assert_eq!(parsed[0][0].text, "Visible");
+    }
+
+    #[test]
+    fn rejects_unbalanced_groups() {
+        assert!(matches!(
+            parse_rtf(br"{\rtf1 broken"),
+            Err(DocumentParseError::UnbalancedGroup { .. })
+        ));
+        assert!(matches!(
+            parse_rtf(br"{\rtf1} }"),
+            Err(DocumentParseError::UnbalancedGroup { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_rtf_text() {
+        assert_eq!(
+            parse_rtf(b"plain text"),
+            Err(DocumentParseError::MissingHeader)
+        );
+        assert_eq!(
+            parse_rtf(br"{not RTF}"),
+            Err(DocumentParseError::MissingHeader)
+        );
+    }
+
+    #[test]
+    fn source_ranges_are_valid() {
+        let input = br"{\rtf1 first\par second}";
+        let blocks = parse_rtf(input).unwrap();
+        assert!(
+            blocks
+                .iter()
+                .all(
+                    |DocBlock { source_range, .. }| source_range.start <= source_range.end
+                        && source_range.end <= input.len()
+                )
+        );
+    }
+
+    #[test]
+    fn deeply_nested_groups_do_not_recurse() {
+        let mut input = Vec::from(&b"{\\rtf1 "[..]);
+        input.extend(std::iter::repeat_n(b'{', 10_000));
+        input.extend_from_slice(b"text");
+        input.extend(std::iter::repeat_n(b'}', 10_001));
+        assert_eq!(paragraphs(&input).unwrap()[0][0].text, "text");
+    }
+}

--- a/crates/sourcefour-doc/src/rtf.rs
+++ b/crates/sourcefour-doc/src/rtf.rs
@@ -3,7 +3,13 @@
 use encoding_rs::{Encoding, WINDOWS_1252};
 use rtf_grimoire::tokenizer::{Token, read_token};
 
-use crate::{DocBlock, DocBlockKind, DocSpan, DocumentKind, parse_markdown};
+use crate::{
+    DocBlock, DocBlockKind, DocColor, DocSpan, DocumentKind, EmbeddedImageFormat, EmbeddedMedia,
+    ParagraphAlignment, ParagraphStyle, VerticalPosition, parse_markdown,
+};
+
+const EMBEDDED_MEDIA_LIMIT: usize = 20 * 1024 * 1024;
+const EMBEDDED_MEDIA_TOTAL_LIMIT: usize = 50 * 1024 * 1024;
 
 /// Why document bytes could not be converted into preview blocks.
 #[derive(Debug, thiserror::Error, Eq, PartialEq)]
@@ -51,7 +57,7 @@ pub fn parse_document(
 /// Returns an error when the token stream is malformed, has unbalanced groups,
 /// or does not declare an RTF document at its root.
 pub fn parse_rtf(bytes: &[u8]) -> Result<Vec<DocBlock>, DocumentParseError> {
-    let mut interpreter = Interpreter::default();
+    let mut interpreter = Interpreter::new(Catalogs::parse(bytes));
     let mut remaining = bytes;
 
     while !remaining.is_empty() {
@@ -80,10 +86,16 @@ struct Style {
     underline: bool,
     strike: bool,
     link: Option<String>,
+    foreground: Option<usize>,
+    highlight: Option<usize>,
+    font: Option<i32>,
+    font_size_half_points: Option<u16>,
+    small_caps: bool,
+    vertical: VerticalPosition,
 }
 
 impl Style {
-    fn span(&self, text: String) -> DocSpan {
+    fn span(&self, text: String, catalogs: &Catalogs) -> DocSpan {
         DocSpan {
             text,
             bold: self.bold,
@@ -92,6 +104,37 @@ impl Style {
             strike: self.strike,
             underline: self.underline,
             link: self.link.clone(),
+            foreground: self
+                .foreground
+                .and_then(|index| catalogs.colors.get(index).copied()),
+            highlight: self
+                .highlight
+                .and_then(|index| catalogs.colors.get(index).copied()),
+            font_family: self.font.and_then(|index| {
+                catalogs
+                    .fonts
+                    .iter()
+                    .find(|(id, _)| *id == index)
+                    .map(|(_, name)| name.clone())
+            }),
+            font_size_half_points: self.font_size_half_points,
+            small_caps: self.small_caps,
+            vertical: self.vertical,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Catalogs {
+    fonts: Vec<(i32, String)>,
+    colors: Vec<DocColor>,
+}
+
+impl Catalogs {
+    fn parse(bytes: &[u8]) -> Self {
+        Self {
+            fonts: destination(bytes, b"fonttbl").map_or_else(Vec::new, parse_fonts),
+            colors: destination(bytes, b"colortbl").map_or_else(Vec::new, parse_colors),
         }
     }
 }
@@ -117,6 +160,9 @@ struct GroupState {
     at_start: bool,
     starred: bool,
     kind: GroupKind,
+    paragraph: ParagraphStyle,
+    heading_level: Option<u8>,
+    list_level: Option<u8>,
 }
 
 impl Default for GroupState {
@@ -128,17 +174,22 @@ impl Default for GroupState {
             at_start: true,
             starred: false,
             kind: GroupKind::Normal,
+            paragraph: ParagraphStyle::default(),
+            heading_level: None,
+            list_level: None,
         }
     }
 }
 
-#[derive(Default)]
 struct Interpreter {
     groups: Vec<GroupState>,
     blocks: Vec<DocBlock>,
     spans: Vec<DocSpan>,
     paragraph_start: Option<usize>,
     paragraph_end: usize,
+    paragraph_style: Option<ParagraphStyle>,
+    paragraph_heading: Option<u8>,
+    paragraph_list_level: Option<u8>,
     code_page: u16,
     fallback_remaining: usize,
     pending_surrogate: Option<u16>,
@@ -147,9 +198,71 @@ struct Interpreter {
     hex_end: usize,
     hex_style: Option<Style>,
     saw_header: bool,
+    catalogs: Catalogs,
+    media_bytes: usize,
+    picture: Option<Picture>,
+    aside: Option<AsideCapture>,
+    table: Option<TableCapture>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct Picture {
+    depth: usize,
+    format: Option<EmbeddedImageFormat>,
+    unsupported: Option<&'static str>,
+    hex: Vec<u8>,
+    nibble: Option<u8>,
+    start: usize,
+}
+
+#[derive(Clone, Debug)]
+struct AsideCapture {
+    depth: usize,
+    label: &'static str,
+    block_start: usize,
+    start: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TableCapture {
+    start: usize,
+    cells: Vec<Vec<DocSpan>>,
 }
 
 impl Interpreter {
+    fn new(catalogs: Catalogs) -> Self {
+        Self {
+            catalogs,
+            code_page: 1252,
+            ..Self::default_fields()
+        }
+    }
+
+    fn default_fields() -> Self {
+        Self {
+            groups: Vec::new(),
+            blocks: Vec::new(),
+            spans: Vec::new(),
+            paragraph_start: None,
+            paragraph_end: 0,
+            paragraph_style: None,
+            paragraph_heading: None,
+            paragraph_list_level: None,
+            code_page: 0,
+            fallback_remaining: 0,
+            pending_surrogate: None,
+            hex_bytes: Vec::new(),
+            hex_start: 0,
+            hex_end: 0,
+            hex_style: None,
+            saw_header: false,
+            catalogs: Catalogs::default(),
+            media_bytes: 0,
+            picture: None,
+            aside: None,
+            table: None,
+        }
+    }
     fn token(&mut self, token: Token, start: usize, end: usize) -> Result<(), DocumentParseError> {
         if !matches!(token, Token::ControlWord { ref name, .. } if name == "'") {
             self.flush_hex();
@@ -158,7 +271,8 @@ impl Interpreter {
         match token {
             Token::StartGroup => self.start_group(),
             Token::EndGroup => self.end_group(start)?,
-            Token::Newline(_) | Token::ControlBin(_) => {}
+            Token::Newline(_) => {}
+            Token::ControlBin(bytes) => self.binary(&bytes, start, end),
             Token::ControlSymbol(symbol) => self.control_symbol(symbol, start, end),
             Token::ControlWord { name, arg } => self.control_word(&name, arg, start, end),
             Token::Text(bytes) => self.text(&bytes, start, end),
@@ -182,6 +296,20 @@ impl Interpreter {
             .groups
             .pop()
             .ok_or(DocumentParseError::UnbalancedGroup { offset })?;
+        if self
+            .picture
+            .as_ref()
+            .is_some_and(|picture| picture.depth == self.groups.len() + 1)
+        {
+            self.finish_picture(offset);
+        }
+        if self
+            .aside
+            .as_ref()
+            .is_some_and(|aside| aside.depth == self.groups.len() + 1)
+        {
+            self.finish_aside(offset);
+        }
         if let GroupKind::FieldInstruction { text } = ended.kind
             && let Some(field) = self
                 .groups
@@ -219,7 +347,23 @@ impl Interpreter {
         self.emit(text, start, end);
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one flat RTF control-word dispatch is easier to audit against the format"
+    )]
     fn control_word(&mut self, name: &str, arg: Option<i32>, start: usize, end: usize) {
+        if let Some(picture) = &mut self.picture {
+            match name {
+                "pngblip" => picture.format = Some(EmbeddedImageFormat::Png),
+                "jpegblip" => {
+                    picture.format = Some(EmbeddedImageFormat::Jpeg);
+                }
+                "emfblip" => picture.unsupported = Some("EMF image"),
+                "wmetafile" => picture.unsupported = Some("WMF image"),
+                _ => {}
+            }
+            return;
+        }
         if name == "'" {
             self.hex(arg, start, end);
             return;
@@ -230,6 +374,19 @@ impl Interpreter {
             self.saw_header = true;
         }
         if at_start {
+            if matches!(
+                name,
+                "pict"
+                    | "header"
+                    | "headerl"
+                    | "headerr"
+                    | "footer"
+                    | "footerl"
+                    | "footerr"
+                    | "footnote"
+            ) {
+                self.flush_paragraph(start);
+            }
             self.open_destination(name);
         }
         let Some(group) = self.groups.last_mut() else {
@@ -259,6 +416,41 @@ impl Interpreter {
             }
             "ulnone" => group.style.underline = false,
             "strike" => group.style.strike = enabled(arg),
+            "f" => group.style.font = arg,
+            "fs" => {
+                group.style.font_size_half_points = arg.and_then(|value| u16::try_from(value).ok());
+            }
+            "cf" => group.style.foreground = arg.and_then(|value| usize::try_from(value).ok()),
+            "highlight" => {
+                group.style.highlight = arg.and_then(|value| usize::try_from(value).ok());
+            }
+            "scaps" => group.style.small_caps = enabled(arg),
+            "super" => group.style.vertical = VerticalPosition::Superscript,
+            "sub" => group.style.vertical = VerticalPosition::Subscript,
+            "nosupersub" => group.style.vertical = VerticalPosition::Normal,
+            "ql" => group.paragraph.alignment = ParagraphAlignment::Left,
+            "qc" => group.paragraph.alignment = ParagraphAlignment::Center,
+            "qr" => group.paragraph.alignment = ParagraphAlignment::Right,
+            "qj" => group.paragraph.alignment = ParagraphAlignment::Justify,
+            "li" => group.paragraph.left_indent_twips = arg.unwrap_or_default(),
+            "ri" => group.paragraph.right_indent_twips = arg.unwrap_or_default(),
+            "fi" => group.paragraph.first_line_indent_twips = arg.unwrap_or_default(),
+            "sb" => group.paragraph.space_before_twips = arg.unwrap_or_default(),
+            "sa" => group.paragraph.space_after_twips = arg.unwrap_or_default(),
+            "pard" => {
+                group.paragraph = ParagraphStyle::default();
+                group.heading_level = None;
+                group.list_level = None;
+            }
+            "outlinelevel" => {
+                group.heading_level = arg
+                    .and_then(|value| u8::try_from(value + 1).ok())
+                    .filter(|level| (1..=6).contains(level));
+            }
+            "ilvl" => group.list_level = arg.and_then(|value| u8::try_from(value).ok()),
+            "ls" => {
+                group.list_level.get_or_insert(0);
+            }
             "plain" => {
                 let link = group.style.link.take();
                 group.style = Style {
@@ -273,6 +465,22 @@ impl Interpreter {
             }
             "u" => self.unicode(arg, start, end),
             "par" => self.flush_paragraph(end),
+            "page" | "sect" => {
+                self.flush_paragraph(start);
+                self.blocks.push(DocBlock {
+                    kind: DocBlockKind::PageBreak,
+                    source_range: start..end,
+                });
+            }
+            "trowd" => {
+                self.flush_paragraph(start);
+                self.table = Some(TableCapture {
+                    start,
+                    ..TableCapture::default()
+                });
+            }
+            "cell" => self.finish_cell(),
+            "row" => self.finish_table(end),
             "line" => self.emit("\n", start, end),
             "tab" => self.emit("\t", start, end),
             "emdash" => self.emit("—", start, end),
@@ -300,6 +508,7 @@ impl Interpreter {
         } else {
             None
         };
+        let depth = self.groups.len();
         let Some(group) = self.groups.last_mut() else {
             return;
         };
@@ -314,12 +523,67 @@ impl Interpreter {
                 group.kind = GroupKind::FieldResult;
                 group.style.link = field_url;
             }
+            "pict" => {
+                group.skip = true;
+                self.picture = Some(Picture {
+                    depth,
+                    start: 0,
+                    ..Picture::default()
+                });
+            }
+            "header" | "headerl" | "headerr" => {
+                self.aside = Some(AsideCapture {
+                    depth,
+                    label: "Header",
+                    block_start: self.blocks.len(),
+                    start: 0,
+                });
+            }
+            "footer" | "footerl" | "footerr" => {
+                self.aside = Some(AsideCapture {
+                    depth,
+                    label: "Footer",
+                    block_start: self.blocks.len(),
+                    start: 0,
+                });
+            }
+            "footnote" => {
+                self.aside = Some(AsideCapture {
+                    depth,
+                    label: "Footnote",
+                    block_start: self.blocks.len(),
+                    start: 0,
+                });
+            }
             name if group.starred || ignored_destination(name) => group.skip = true,
             _ => {}
         }
     }
 
     fn text(&mut self, bytes: &[u8], start: usize, end: usize) {
+        if let Some(picture) = &mut self.picture {
+            if picture.start == 0 {
+                picture.start = start;
+            }
+            for byte in bytes
+                .iter()
+                .copied()
+                .filter(|byte| !byte.is_ascii_whitespace())
+            {
+                let Some(value) = hex_value(byte) else {
+                    continue;
+                };
+                if let Some(high) = picture.nibble.take() {
+                    if picture.hex.len() < EMBEDDED_MEDIA_LIMIT {
+                        picture.hex.push((high << 4) | value);
+                    }
+                } else {
+                    picture.nibble = Some(value);
+                }
+            }
+            self.paragraph_end = self.paragraph_end.max(end);
+            return;
+        }
         let Some(group) = self.groups.last() else {
             return;
         };
@@ -343,6 +607,20 @@ impl Interpreter {
             self.flush_pending_surrogate(start);
             self.emit(&decoded, start + skip, end);
         }
+    }
+
+    fn binary(&mut self, bytes: &[u8], start: usize, end: usize) {
+        let Some(picture) = &mut self.picture else {
+            return;
+        };
+        if picture.start == 0 {
+            picture.start = start;
+        }
+        let remaining = EMBEDDED_MEDIA_LIMIT.saturating_sub(picture.hex.len());
+        picture
+            .hex
+            .extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+        self.paragraph_end = self.paragraph_end.max(end);
     }
 
     fn hex(&mut self, arg: Option<i32>, start: usize, end: usize) {
@@ -431,6 +709,18 @@ impl Interpreter {
         }
         let style = style.unwrap_or_default();
         self.paragraph_start.get_or_insert(start);
+        if self.paragraph_style.is_none()
+            && let Some(group) = self.groups.last()
+        {
+            self.paragraph_style = Some(group.paragraph);
+            self.paragraph_heading = group.heading_level;
+            self.paragraph_list_level = group.list_level;
+        }
+        if let Some(aside) = &mut self.aside
+            && aside.start == 0
+        {
+            aside.start = start;
+        }
         self.paragraph_end = self.paragraph_end.max(end);
         if let Some(last) = self.spans.last_mut()
             && last.bold == style.bold
@@ -438,10 +728,29 @@ impl Interpreter {
             && last.underline == style.underline
             && last.strike == style.strike
             && last.link == style.link
+            && last.foreground
+                == style
+                    .foreground
+                    .and_then(|index| self.catalogs.colors.get(index).copied())
+            && last.highlight
+                == style
+                    .highlight
+                    .and_then(|index| self.catalogs.colors.get(index).copied())
+            && last.font_family.as_deref()
+                == style.font.and_then(|index| {
+                    self.catalogs
+                        .fonts
+                        .iter()
+                        .find(|(id, _)| *id == index)
+                        .map(|(_, name)| name.as_str())
+                })
+            && last.font_size_half_points == style.font_size_half_points
+            && last.small_caps == style.small_caps
+            && last.vertical == style.vertical
         {
             last.text.push_str(text);
         } else {
-            self.spans.push(style.span(text.to_owned()));
+            self.spans.push(style.span(text.to_owned(), &self.catalogs));
         }
     }
 
@@ -451,13 +760,144 @@ impl Interpreter {
             return;
         }
         let start = self.paragraph_start.take().unwrap_or(end);
-        self.blocks.push(DocBlock {
-            kind: DocBlockKind::Paragraph {
-                spans: std::mem::take(&mut self.spans),
-            },
-            source_range: start..end.max(self.paragraph_end),
-        });
+        if self.table.is_some() {
+            self.finish_cell();
+            self.paragraph_start = None;
+            self.paragraph_end = 0;
+            self.paragraph_style = None;
+            self.paragraph_heading = None;
+            self.paragraph_list_level = None;
+            return;
+        }
+        let style = self.paragraph_style.take().unwrap_or_default();
+        let heading = self.paragraph_heading.take();
+        let list_level = self.paragraph_list_level.take();
+        let spans = std::mem::take(&mut self.spans);
+        let source_range = start..end.max(self.paragraph_end);
+        if let Some(level) = heading {
+            self.blocks.push(DocBlock {
+                kind: DocBlockKind::Heading { level, spans },
+                source_range,
+            });
+        } else if list_level.is_some() {
+            let item = vec![DocBlock {
+                kind: DocBlockKind::RichParagraph { spans, style },
+                source_range: source_range.clone(),
+            }];
+            if let Some(DocBlock {
+                kind:
+                    DocBlockKind::List {
+                        ordered: false,
+                        items,
+                    },
+                source_range: range,
+            }) = self.blocks.last_mut()
+            {
+                items.push(item);
+                range.end = source_range.end;
+            } else {
+                self.blocks.push(DocBlock {
+                    kind: DocBlockKind::List {
+                        ordered: false,
+                        items: vec![item],
+                    },
+                    source_range,
+                });
+            }
+        } else {
+            self.blocks.push(DocBlock {
+                kind: DocBlockKind::RichParagraph { spans, style },
+                source_range,
+            });
+        }
         self.paragraph_end = 0;
+    }
+
+    fn finish_cell(&mut self) {
+        if let Some(table) = &mut self.table
+            && !self.spans.is_empty()
+        {
+            table.cells.push(std::mem::take(&mut self.spans));
+            self.paragraph_start = None;
+            self.paragraph_end = 0;
+            self.paragraph_style = None;
+            self.paragraph_heading = None;
+            self.paragraph_list_level = None;
+        }
+    }
+
+    fn finish_table(&mut self, end: usize) {
+        self.finish_cell();
+        let Some(table) = self.table.take() else {
+            return;
+        };
+        if table.cells.is_empty() {
+            return;
+        }
+        self.blocks.push(DocBlock {
+            kind: DocBlockKind::Table {
+                alignments: vec![crate::CellAlignment::Left; table.cells.len()],
+                header: Vec::new(),
+                rows: vec![table.cells],
+            },
+            source_range: table.start..end,
+        });
+    }
+
+    fn finish_aside(&mut self, end: usize) {
+        self.flush_paragraph(end);
+        let Some(aside) = self.aside.take() else {
+            return;
+        };
+        let blocks = self.blocks.split_off(aside.block_start);
+        if !blocks.is_empty() {
+            self.blocks.push(DocBlock {
+                kind: DocBlockKind::Aside {
+                    label: aside.label.to_owned(),
+                    blocks,
+                },
+                source_range: aside.start..end,
+            });
+        }
+    }
+
+    fn finish_picture(&mut self, end: usize) {
+        let Some(picture) = self.picture.take() else {
+            return;
+        };
+        self.flush_paragraph(picture.start);
+        let media = if picture.nibble.is_some() {
+            EmbeddedMedia::Unsupported {
+                label: String::from("malformed embedded image"),
+            }
+        } else if picture.hex.len() >= EMBEDDED_MEDIA_LIMIT
+            || self.media_bytes.saturating_add(picture.hex.len()) > EMBEDDED_MEDIA_TOTAL_LIMIT
+        {
+            EmbeddedMedia::Unsupported {
+                label: String::from("embedded image exceeds preview limit"),
+            }
+        } else if let Some(label) = picture.unsupported {
+            EmbeddedMedia::Unsupported {
+                label: label.to_owned(),
+            }
+        } else if let Some(format) = picture.format {
+            self.media_bytes += picture.hex.len();
+            EmbeddedMedia::Image {
+                format,
+                bytes: picture.hex,
+            }
+        } else {
+            EmbeddedMedia::Unsupported {
+                label: String::from("unsupported embedded image"),
+            }
+        };
+        self.blocks.push(DocBlock {
+            kind: DocBlockKind::EmbeddedMedia {
+                media,
+                alt: String::from("Embedded RTF image"),
+            },
+            source_range: picture.start..end,
+        });
     }
 
     fn finish(mut self, offset: usize) -> Result<Vec<DocBlock>, DocumentParseError> {
@@ -478,6 +918,92 @@ fn enabled(arg: Option<i32>) -> bool {
     arg != Some(0)
 }
 
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Finds one top-level destination without allocating or recursively parsing.
+fn destination<'a>(bytes: &'a [u8], name: &[u8]) -> Option<&'a [u8]> {
+    let needle = [b"{\\".as_slice(), name].concat();
+    let start = bytes
+        .windows(needle.len())
+        .position(|window| window == needle)?;
+    let mut depth = 0usize;
+    let mut escaped = false;
+    for (index, &byte) in bytes[start..].iter().enumerate() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if byte == b'\\' {
+            escaped = true;
+        } else if byte == b'{' {
+            depth += 1;
+        } else if byte == b'}' {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                return bytes.get(start..=start + index);
+            }
+        }
+    }
+    None
+}
+
+fn parse_fonts(bytes: &[u8]) -> Vec<(i32, String)> {
+    let text = String::from_utf8_lossy(bytes);
+    text.split(';')
+        .filter_map(|entry| {
+            let marker = entry.match_indices("\\f").find_map(|(index, _)| {
+                entry
+                    .as_bytes()
+                    .get(index + 2)
+                    .is_some_and(u8::is_ascii_digit)
+                    .then_some(index + 2)
+            })?;
+            let digits = entry[marker..]
+                .chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>();
+            let id = digits.parse().ok()?;
+            let name = entry
+                .split(' ')
+                .next_back()?
+                .trim_matches(|character: char| matches!(character, '{' | '}' | '\n' | '\r'));
+            (!name.is_empty()).then(|| (id, name.to_owned()))
+        })
+        .collect()
+}
+
+fn parse_colors(bytes: &[u8]) -> Vec<DocColor> {
+    let text = String::from_utf8_lossy(bytes);
+    text.split(';')
+        .map(|entry| DocColor {
+            red: color_component(entry, "\\red"),
+            green: color_component(entry, "\\green"),
+            blue: color_component(entry, "\\blue"),
+        })
+        .collect()
+}
+
+fn color_component(entry: &str, marker: &str) -> u8 {
+    entry
+        .find(marker)
+        .and_then(|start| {
+            entry[start + marker.len()..]
+                .chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse()
+                .ok()
+        })
+        .unwrap_or_default()
+}
+
 fn ignored_destination(name: &str) -> bool {
     matches!(
         name,
@@ -485,7 +1011,6 @@ fn ignored_destination(name: &str) -> bool {
             | "colortbl"
             | "stylesheet"
             | "info"
-            | "pict"
             | "object"
             | "objdata"
             | "header"
@@ -561,7 +1086,8 @@ mod tests {
             blocks
                 .into_iter()
                 .filter_map(|block| match block.kind {
-                    DocBlockKind::Paragraph { spans } => Some(spans),
+                    DocBlockKind::Paragraph { spans }
+                    | DocBlockKind::RichParagraph { spans, .. } => Some(spans),
                     _ => None,
                 })
                 .collect()
@@ -681,5 +1207,74 @@ mod tests {
         input.extend_from_slice(b"text");
         input.extend(std::iter::repeat_n(b'}', 10_001));
         assert_eq!(paragraphs(&input).unwrap()[0][0].text, "text");
+    }
+
+    #[test]
+    fn retains_catalog_colors_fonts_and_paragraph_layout() {
+        let blocks = parse_rtf(br"{\rtf1{\fonttbl{\f0 Helvetica;}}{\colortbl;\red240\green20\blue40;}\qc\li300\sa120\f0\fs28\cf1\highlight1 Hello}").unwrap();
+        let DocBlockKind::RichParagraph { spans, style } = &blocks[0].kind else {
+            panic!("expected rich paragraph");
+        };
+        assert_eq!(style.alignment, crate::ParagraphAlignment::Center);
+        assert_eq!(style.left_indent_twips, 300);
+        assert_eq!(style.space_after_twips, 120);
+        assert_eq!(spans[0].font_family.as_deref(), Some("Helvetica"));
+        assert_eq!(spans[0].font_size_half_points, Some(28));
+        assert_eq!(
+            spans[0].foreground,
+            Some(crate::DocColor {
+                red: 240,
+                green: 20,
+                blue: 40
+            })
+        );
+        assert_eq!(spans[0].highlight, spans[0].foreground);
+    }
+
+    #[test]
+    fn retains_headings_lists_tables_and_page_breaks() {
+        let blocks = parse_rtf(br"{\rtf1\outlinelevel1 Heading\par\pard\ls1\ilvl0 One\par Two\par\pard\trowd A\cell B\cell\row\page End}").unwrap();
+        assert!(matches!(
+            blocks[0].kind,
+            DocBlockKind::Heading { level: 2, .. }
+        ));
+        assert!(matches!(blocks[1].kind, DocBlockKind::List { ref items, .. } if items.len() == 2));
+        assert!(
+            matches!(blocks[2].kind, DocBlockKind::Table { ref rows, .. } if rows[0].len() == 2)
+        );
+        assert!(
+            blocks
+                .iter()
+                .any(|block| matches!(block.kind, DocBlockKind::PageBreak))
+        );
+    }
+
+    #[test]
+    fn decodes_supported_pictures_and_labels_unsupported_ones() {
+        let blocks = parse_rtf(br"{\rtf1{\pict\pngblip 89504e47}{\pict\emfblip 0102}}").unwrap();
+        assert!(
+            matches!(blocks[0].kind, DocBlockKind::EmbeddedMedia { media: crate::EmbeddedMedia::Image { format: crate::EmbeddedImageFormat::Png, ref bytes }, .. } if bytes == &[0x89, 0x50, 0x4e, 0x47])
+        );
+        assert!(
+            matches!(blocks[1].kind, DocBlockKind::EmbeddedMedia { media: crate::EmbeddedMedia::Unsupported { ref label }, .. } if label == "EMF image")
+        );
+    }
+
+    #[test]
+    fn accepts_binary_picture_payloads() {
+        let blocks = parse_rtf(br"{\rtf1{\pict\jpegblip\bin4 ABCD}}").unwrap();
+        assert!(
+            matches!(blocks[0].kind, DocBlockKind::EmbeddedMedia { media: crate::EmbeddedMedia::Image { format: crate::EmbeddedImageFormat::Jpeg, ref bytes }, .. } if bytes == b"ABCD")
+        );
+    }
+
+    #[test]
+    fn captures_secondary_document_areas_as_labeled_asides() {
+        let blocks =
+            parse_rtf(br"{\rtf1{\header Running title\par}Body{\footnote Note text}}").unwrap();
+        assert!(
+            matches!(blocks[0].kind, DocBlockKind::Aside { ref label, .. } if label == "Header")
+        );
+        assert!(blocks.iter().any(|block| matches!(block.kind, DocBlockKind::Aside { ref label, .. } if label == "Footnote")));
     }
 }

--- a/crates/sourcefour-git/src/branch.rs
+++ b/crates/sourcefour-git/src/branch.rs
@@ -3,8 +3,8 @@
 use std::process::Command;
 
 use sourcefour_model::{
-    CreateBranchRequest, OperationKind, OperationOutcome, RepoFailure, RepoFailureKind,
-    RepoLocation,
+    CheckoutBranchRequest, CreateBranchRequest, OperationKind, OperationOutcome, RepoFailure,
+    RepoFailureKind, RepoLocation, TrackRemoteBranchRequest,
 };
 
 /// The exact §6.13 argv; arguments are passed discretely, never joined into
@@ -20,6 +20,25 @@ fn branch_argv(request: &CreateBranchRequest) -> Vec<String> {
         ]
     } else {
         vec![String::from("branch"), request.name.clone(), start]
+    }
+}
+
+fn tracking_argv(request: &TrackRemoteBranchRequest) -> Vec<String> {
+    if request.checkout {
+        vec![
+            String::from("switch"),
+            String::from("-c"),
+            request.local_name.clone(),
+            String::from("--track"),
+            request.remote_ref.clone(),
+        ]
+    } else {
+        vec![
+            String::from("branch"),
+            String::from("--track"),
+            request.local_name.clone(),
+            request.remote_ref.clone(),
+        ]
     }
 }
 
@@ -121,13 +140,136 @@ pub fn create_branch(
     }
 }
 
+/// Creates a local branch with an explicit remote-tracking upstream.
+///
+/// # Errors
+///
+/// Returns a typed failure when Git cannot be started. Git command failures
+/// are returned as operation outcomes so the UI can keep its dialog open.
+pub fn track_remote_branch(
+    location: &RepoLocation,
+    request: &TrackRemoteBranchRequest,
+) -> Result<OperationOutcome, RepoFailure> {
+    let kind = if request.checkout {
+        OperationKind::TrackAndCheckoutRemoteBranch
+    } else {
+        OperationKind::TrackRemoteBranch
+    };
+    if !is_valid_branch_name(&request.local_name)
+        || !request.remote_ref.starts_with("refs/remotes/")
+    {
+        return Ok(OperationOutcome::Failed {
+            kind,
+            error: RepoFailure::new(
+                RepoFailureKind::Internal,
+                "Invalid tracking branch",
+                "The local or remote branch name is not valid.",
+            ),
+        });
+    }
+    let workdir = location
+        .active_worktree_path
+        .as_deref()
+        .unwrap_or(&location.common_dir);
+    let output = Command::new("git")
+        .args(tracking_argv(request))
+        .current_dir(workdir)
+        .output()
+        .map_err(|error| {
+            RepoFailure::new(
+                RepoFailureKind::Internal,
+                "Git could not be started",
+                "The installed git executable could not be run.",
+            )
+            .with_details(error.to_string())
+        })?;
+    if output.status.success() {
+        Ok(OperationOutcome::Succeeded {
+            kind,
+            summary: if request.checkout {
+                format!("Created and switched to {}", request.local_name)
+            } else {
+                format!("Created {}", request.local_name)
+            },
+        })
+    } else {
+        Ok(OperationOutcome::Failed {
+            kind,
+            error: RepoFailure::new(
+                RepoFailureKind::OperationConflict,
+                "Tracking branch could not be created",
+                String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+            ),
+        })
+    }
+}
+
+/// Switches the active worktree to an existing local branch.
+///
+/// # Errors
+///
+/// Returns a typed failure when Git cannot be started.
+pub fn checkout_branch(
+    location: &RepoLocation,
+    request: &CheckoutBranchRequest,
+) -> Result<OperationOutcome, RepoFailure> {
+    if !request.full_name.starts_with("refs/heads/") {
+        return Ok(OperationOutcome::Failed {
+            kind: OperationKind::CheckoutBranch,
+            error: RepoFailure::new(
+                RepoFailureKind::Internal,
+                "Invalid branch",
+                "Only a local branch can be checked out.",
+            ),
+        });
+    }
+    let workdir = location
+        .active_worktree_path
+        .as_deref()
+        .unwrap_or(&location.common_dir);
+    let short_name = request.full_name.trim_start_matches("refs/heads/");
+    let output = Command::new("git")
+        .args(["switch", short_name])
+        .current_dir(workdir)
+        .output()
+        .map_err(|error| {
+            RepoFailure::new(
+                RepoFailureKind::Internal,
+                "Git could not be started",
+                "The installed git executable could not be run.",
+            )
+            .with_details(error.to_string())
+        })?;
+    if output.status.success() {
+        Ok(OperationOutcome::Succeeded {
+            kind: OperationKind::CheckoutBranch,
+            summary: format!("Switched to {short_name}"),
+        })
+    } else {
+        Ok(OperationOutcome::Failed {
+            kind: OperationKind::CheckoutBranch,
+            error: RepoFailure::new(
+                RepoFailureKind::OperationConflict,
+                "Branch could not be checked out",
+                String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+            ),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use sourcefour_model::{CreateBranchRequest, Oid, OperationOutcome, WorktreeId};
+    use sourcefour_model::{
+        CheckoutBranchRequest, CreateBranchRequest, Oid, OperationOutcome,
+        TrackRemoteBranchRequest, WorktreeId,
+    };
     use sourcefour_test_support::TempRepo;
 
-    use super::{branch_argv, create_branch, is_valid_branch_name};
-    use crate::discover;
+    use super::{
+        branch_argv, checkout_branch, create_branch, is_valid_branch_name, track_remote_branch,
+        tracking_argv,
+    };
+    use crate::{discover, references};
 
     fn request(name: &str, start: Oid, checkout: bool) -> CreateBranchRequest {
         CreateBranchRequest {
@@ -155,6 +297,93 @@ mod tests {
             branch_argv(&request("feature/x", start, true)),
             ["switch", "-c", "feature/x", hex.as_str()]
         );
+    }
+
+    #[test]
+    fn tracking_argv_is_explicit() {
+        let request = TrackRemoteBranchRequest {
+            worktree: WorktreeId(String::from("test")),
+            remote_ref: String::from("refs/remotes/origin/feature/x"),
+            local_name: String::from("feature/x"),
+            checkout: true,
+        };
+        assert_eq!(
+            tracking_argv(&request),
+            [
+                "switch",
+                "-c",
+                "feature/x",
+                "--track",
+                "refs/remotes/origin/feature/x"
+            ]
+        );
+    }
+
+    #[test]
+    fn tracking_branch_records_its_upstream() -> Result<(), Box<dyn std::error::Error>> {
+        let origin = TempRepo::init();
+        origin.git(&["branch", "feature/remote"]);
+        let repository = TempRepo::clone_of(&origin);
+        let location = discover(repository.path())?;
+        let outcome = track_remote_branch(
+            &location,
+            &TrackRemoteBranchRequest {
+                worktree: WorktreeId(String::from("test")),
+                remote_ref: String::from("refs/remotes/origin/feature/remote"),
+                local_name: String::from("feature/remote"),
+                checkout: false,
+            },
+        )?;
+        assert!(matches!(outcome, OperationOutcome::Succeeded { .. }));
+        let branch = references(&location, &crate::worktrees(&location)?)?
+            .local_branches
+            .into_iter()
+            .find(|branch| branch.short_name == "feature/remote")
+            .expect("branch exists");
+        assert_eq!(branch.upstream.unwrap().short_name, "origin/feature/remote");
+        Ok(())
+    }
+
+    #[test]
+    fn a_tracking_branch_can_be_created_and_checked_out() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let origin = TempRepo::init();
+        origin.git(&["branch", "feature/checkout"]);
+        let repository = TempRepo::clone_of(&origin);
+        let outcome = track_remote_branch(
+            &discover(repository.path())?,
+            &TrackRemoteBranchRequest {
+                worktree: WorktreeId(String::from("test")),
+                remote_ref: String::from("refs/remotes/origin/feature/checkout"),
+                local_name: String::from("feature/checkout"),
+                checkout: true,
+            },
+        )?;
+        assert!(matches!(outcome, OperationOutcome::Succeeded { .. }));
+        assert_eq!(
+            repository.git(&["branch", "--show-current"]),
+            "feature/checkout"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn an_existing_local_branch_can_be_checked_out() -> Result<(), Box<dyn std::error::Error>> {
+        let repository = TempRepo::init();
+        repository.git(&["branch", "feature/existing"]);
+        let outcome = checkout_branch(
+            &discover(repository.path())?,
+            &CheckoutBranchRequest {
+                worktree: WorktreeId(String::from("test")),
+                full_name: String::from("refs/heads/feature/existing"),
+            },
+        )?;
+        assert!(matches!(outcome, OperationOutcome::Succeeded { .. }));
+        assert_eq!(
+            repository.git(&["branch", "--show-current"]),
+            "feature/existing"
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/sourcefour-git/src/fetch.rs
+++ b/crates/sourcefour-git/src/fetch.rs
@@ -26,6 +26,8 @@ fn fetch_argv(request: &FetchRequest) -> Vec<String> {
     }
     if let Some(remote) = &request.remote {
         argv.push(remote.clone());
+    } else {
+        argv.push(String::from("--all"));
     }
     argv
 }
@@ -106,8 +108,8 @@ mod tests {
     fn the_exact_argv_is_stable() {
         assert_eq!(
             fetch_argv(&request(None, false)),
-            ["fetch", "--progress", "--porcelain"],
-            "no remote means all-remotes default"
+            ["fetch", "--progress", "--porcelain", "--all"],
+            "no remote fetches every configured remote"
         );
         assert_eq!(
             fetch_argv(&request(Some("origin"), true)),
@@ -167,6 +169,36 @@ mod tests {
             clone.git(&["rev-parse", "origin/main"]),
             origin.git(&["rev-parse", "main"]),
             "the tracking ref moved to the upstream tip"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn an_all_remote_fetch_discovers_a_non_default_remote_branch()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let origin = TempRepo::init();
+        let upstream = TempRepo::init();
+        upstream.git(&["branch", "feature/upstream-only"]);
+        let clone = TempRepo::clone_of(&origin);
+        clone.git(&[
+            "remote",
+            "add",
+            "upstream",
+            &upstream.path().to_string_lossy(),
+        ]);
+        let sink = CollectingSink(Mutex::new(Vec::new()));
+
+        let outcome = fetch(
+            &discover(clone.path())?,
+            &request(None, false),
+            &sink,
+            &AtomicBool::new(false),
+        )?;
+
+        assert!(matches!(outcome, OperationOutcome::Succeeded { .. }));
+        assert_eq!(
+            clone.git(&["rev-parse", "upstream/feature/upstream-only"]),
+            upstream.git(&["rev-parse", "feature/upstream-only"])
         );
         Ok(())
     }

--- a/crates/sourcefour-git/src/lib.rs
+++ b/crates/sourcefour-git/src/lib.rs
@@ -23,13 +23,14 @@ mod session;
 mod stage;
 mod status;
 mod watch;
+mod worktree_add;
 mod worktrees;
 
 use std::sync::atomic::AtomicBool;
 
 pub use crate::{
     ahead_behind::{AheadBehindCache, apply as apply_ahead_behind},
-    branch::{create_branch, is_valid_branch_name},
+    branch::{checkout_branch, create_branch, is_valid_branch_name, track_remote_branch},
     commit::commit,
     detail::commit_detail,
     diff::{DiffLimits, file_diff, file_diff_with_limits, unified, worktree_file_diff},
@@ -46,6 +47,7 @@ pub use crate::{
     stage::{stage_paths, unstage_paths},
     status::working_tree_status,
     watch::{MetadataChange, MetadataWatcher},
+    worktree_add::{add_worktree, ensure_internal_worktrees_excluded},
     worktrees::worktrees,
 };
 

--- a/crates/sourcefour-git/src/worktree_add.rs
+++ b/crates/sourcefour-git/src/worktree_add.rs
@@ -1,0 +1,209 @@
+//! Linked-worktree creation through the user's installed Git.
+
+use std::{fs::OpenOptions, io::Write, path::Path, process::Command};
+
+use sourcefour_model::{
+    AddWorktreeRequest, OperationKind, OperationOutcome, RepoFailure, RepoFailureKind,
+    RepoLocation, WorktreeSource,
+};
+
+use crate::is_valid_branch_name;
+
+/// Adds the application-managed worktree directory to the repository-local
+/// exclude file without touching the tracked `.gitignore`.
+///
+/// # Errors
+///
+/// Returns an I/O failure when the common repository metadata is not writable.
+pub fn ensure_internal_worktrees_excluded(location: &RepoLocation) -> std::io::Result<()> {
+    let info = location.common_dir.join("info");
+    std::fs::create_dir_all(&info)?;
+    let path = info.join("exclude");
+    let current = std::fs::read_to_string(&path).unwrap_or_default();
+    if current.lines().any(|line| line.trim() == ".worktrees/") {
+        return Ok(());
+    }
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    if !current.is_empty() && !current.ends_with('\n') {
+        writeln!(file)?;
+    }
+    writeln!(file, ".worktrees/")
+}
+
+fn argv(request: &AddWorktreeRequest) -> Vec<String> {
+    let path = request.path.to_string_lossy().into_owned();
+    match &request.source {
+        WorktreeSource::LocalBranch { full_name } => vec![
+            String::from("worktree"),
+            String::from("add"),
+            path,
+            full_name.clone(),
+        ],
+        WorktreeSource::RemoteBranch {
+            full_name,
+            local_name,
+        } => vec![
+            String::from("worktree"),
+            String::from("add"),
+            String::from("--track"),
+            String::from("-b"),
+            local_name.clone(),
+            path,
+            full_name.clone(),
+        ],
+    }
+}
+
+fn target_is_available(path: &Path) -> bool {
+    !path.exists() || std::fs::read_dir(path).is_ok_and(|mut entries| entries.next().is_none())
+}
+
+/// Creates a linked worktree and returns Git's failure without hiding the
+/// currently loaded repository.
+///
+/// # Errors
+///
+/// Returns a typed failure when Git cannot be started.
+pub fn add_worktree(
+    location: &RepoLocation,
+    request: &AddWorktreeRequest,
+) -> Result<OperationOutcome, RepoFailure> {
+    let invalid_source = match &request.source {
+        WorktreeSource::LocalBranch { full_name } => !full_name.starts_with("refs/heads/"),
+        WorktreeSource::RemoteBranch {
+            full_name,
+            local_name,
+        } => !full_name.starts_with("refs/remotes/") || !is_valid_branch_name(local_name),
+    };
+    if invalid_source || !target_is_available(&request.path) {
+        return Ok(OperationOutcome::Failed {
+            kind: OperationKind::AddWorktree,
+            error: RepoFailure::new(
+                RepoFailureKind::OperationConflict,
+                "Worktree could not be created",
+                "Choose an empty or nonexistent path and a valid branch.",
+            ),
+        });
+    }
+    let workdir = location
+        .active_worktree_path
+        .as_deref()
+        .unwrap_or(&location.common_dir);
+    let output = Command::new("git")
+        .args(argv(request))
+        .current_dir(workdir)
+        .output()
+        .map_err(|error| {
+            RepoFailure::new(
+                RepoFailureKind::Internal,
+                "Git could not be started",
+                "The installed git executable could not be run.",
+            )
+            .with_details(error.to_string())
+        })?;
+    if output.status.success() {
+        Ok(OperationOutcome::Succeeded {
+            kind: OperationKind::AddWorktree,
+            summary: format!("Created worktree at {}", request.path.display()),
+        })
+    } else {
+        Ok(OperationOutcome::Failed {
+            kind: OperationKind::AddWorktree,
+            error: RepoFailure::new(
+                RepoFailureKind::OperationConflict,
+                "Worktree could not be created",
+                String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+            ),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sourcefour_model::{AddWorktreeRequest, OperationOutcome, WorktreeId, WorktreeSource};
+    use sourcefour_test_support::TempRepo;
+
+    use super::{add_worktree, argv, ensure_internal_worktrees_excluded};
+    use crate::{discover, references, worktrees};
+
+    #[test]
+    fn local_branch_argv_is_discrete() {
+        let request = AddWorktreeRequest {
+            worktree: WorktreeId(String::from("test")),
+            source: WorktreeSource::LocalBranch {
+                full_name: String::from("refs/heads/feature/a"),
+            },
+            path: "/tmp/a b".into(),
+        };
+        assert_eq!(
+            argv(&request),
+            ["worktree", "add", "/tmp/a b", "refs/heads/feature/a"]
+        );
+    }
+
+    #[test]
+    fn internal_directory_is_excluded_once() -> Result<(), Box<dyn std::error::Error>> {
+        let repository = TempRepo::init();
+        let location = discover(repository.path())?;
+        ensure_internal_worktrees_excluded(&location)?;
+        ensure_internal_worktrees_excluded(&location)?;
+        let exclude = std::fs::read_to_string(location.common_dir.join("info/exclude"))?;
+        assert_eq!(
+            exclude
+                .lines()
+                .filter(|line| line.trim() == ".worktrees/")
+                .count(),
+            1
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn creates_a_worktree_for_a_local_branch() -> Result<(), Box<dyn std::error::Error>> {
+        let repository = TempRepo::init();
+        repository.git(&["branch", "feature/worktree"]);
+        let path = repository.path().parent().unwrap().join("created-worktree");
+        let location = discover(repository.path())?;
+        let outcome = add_worktree(
+            &location,
+            &AddWorktreeRequest {
+                worktree: WorktreeId(String::from("test")),
+                source: WorktreeSource::LocalBranch {
+                    full_name: String::from("refs/heads/feature/worktree"),
+                },
+                path: path.clone(),
+            },
+        )?;
+        assert!(matches!(outcome, OperationOutcome::Succeeded { .. }));
+        assert!(worktrees(&location)?.iter().any(|tree| tree.path == path));
+        Ok(())
+    }
+
+    #[test]
+    fn creates_a_tracking_branch_for_a_remote_source() -> Result<(), Box<dyn std::error::Error>> {
+        let origin = TempRepo::init();
+        origin.git(&["branch", "feature/remote"]);
+        let repository = TempRepo::clone_of(&origin);
+        let path = repository.path().parent().unwrap().join("remote-worktree");
+        let location = discover(repository.path())?;
+        let outcome = add_worktree(
+            &location,
+            &AddWorktreeRequest {
+                worktree: WorktreeId(String::from("test")),
+                source: WorktreeSource::RemoteBranch {
+                    full_name: String::from("refs/remotes/origin/feature/remote"),
+                    local_name: String::from("feature/remote"),
+                },
+                path,
+            },
+        )?;
+        assert!(matches!(outcome, OperationOutcome::Succeeded { .. }));
+        let branch = references(&location, &worktrees(&location)?)?
+            .local_branches
+            .into_iter()
+            .find(|branch| branch.short_name == "feature/remote")
+            .expect("tracking branch exists");
+        assert_eq!(branch.upstream.unwrap().short_name, "origin/feature/remote");
+        Ok(())
+    }
+}

--- a/crates/sourcefour-model/src/lib.rs
+++ b/crates/sourcefour-model/src/lib.rs
@@ -1005,6 +1005,14 @@ pub enum OperationKind {
     CreateBranch,
     /// Create and check out a branch.
     CreateAndCheckoutBranch,
+    /// Switch the active worktree to an existing local branch.
+    CheckoutBranch,
+    /// Create a local branch which tracks a remote-tracking branch.
+    TrackRemoteBranch,
+    /// Create and check out a local branch which tracks a remote branch.
+    TrackAndCheckoutRemoteBranch,
+    /// Create a linked worktree.
+    AddWorktree,
     /// Record the staged changes as a commit.
     Commit,
 }
@@ -1044,6 +1052,51 @@ pub struct CreateBranchRequest {
     pub start: Oid,
     /// Whether the new branch should become active.
     pub checkout: bool,
+}
+
+/// User-requested checkout of an existing local branch.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CheckoutBranchRequest {
+    /// Worktree used as the Git command context.
+    pub worktree: WorktreeId,
+    /// Fully qualified local branch ref.
+    pub full_name: String,
+}
+
+/// User-requested creation of a local branch tracking a remote branch.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrackRemoteBranchRequest {
+    /// Worktree used as the Git command context.
+    pub worktree: WorktreeId,
+    /// Fully qualified remote-tracking ref.
+    pub remote_ref: String,
+    /// New local branch name.
+    pub local_name: String,
+    /// Whether the new branch should become active.
+    pub checkout: bool,
+}
+
+/// Branch source for a new linked worktree.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WorktreeSource {
+    /// An existing local branch.
+    LocalBranch { full_name: String },
+    /// A remote-tracking branch which needs a new local tracking branch.
+    RemoteBranch {
+        full_name: String,
+        local_name: String,
+    },
+}
+
+/// User-requested linked worktree creation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AddWorktreeRequest {
+    /// Worktree used as the Git command context.
+    pub worktree: WorktreeId,
+    /// Branch to check out in the new worktree.
+    pub source: WorktreeSource,
+    /// New checkout directory.
+    pub path: PathBuf,
 }
 
 /// Result of an explicit Git operation.


### PR DESCRIPTION
## What changed

- expands RTF parsing beyond basic styled prose to retain font and color tables, paragraph alignment, indentation, spacing, headings, lists, tables, and page boundaries
- renders headers, footers, and footnotes as labeled secondary sections
- previews embedded PNG and JPEG payloads, including binary RTF payloads
- shows explicit placeholders for unsupported, malformed, and oversized embedded media
- adapts document foreground and highlight colors to the active Sourcefour theme

## Why

RTF previews previously discarded most document structure and embedded content. This makes the preview useful for broader real-world RTF documents while preserving selectable, stable text flow and keeping unsupported content visible.

## Impact

- no new runtime dependencies
- embedded media is limited to 20 MiB per item and 50 MiB per document side
- release binary increased by 33,072 bytes (0.22%), from 15,139,648 to 15,172,720 bytes

## Validation

- `just check`
- 404 workspace tests passed
- formatting and Clippy pass with warnings denied
- release build completed within the agreed 5% binary-size ceiling
